### PR TITLE
Fix nicknames not appearing in chat

### DIFF
--- a/src/main/kotlin/com/projectcitybuild/features/chat/listeners/ChatListener.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/chat/listeners/ChatListener.kt
@@ -18,7 +18,10 @@ class ChatListener(
             plugin,
             event.player,
             SubChannel.GLOBAL_CHAT,
-            arrayOf(event.message)
+            arrayOf(
+                event.message,
+                event.player.displayName,
+            )
         ).send()
 
         // Super unsafe, but no other option as cancelling the event (as per the

--- a/src/main/kotlin/com/projectcitybuild/features/chat/listeners/IncomingChatListener.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/chat/listeners/IncomingChatListener.kt
@@ -38,6 +38,8 @@ class IncomingChatListener(
             var recipients = proxy.players
 
             val message = stream.readUTF()
+            val senderDisplayName = stream.readUTF()
+
             val sender = event.receiver
             val player = sender as? ProxiedPlayer
                 ?: return@launch
@@ -59,7 +61,7 @@ class IncomingChatListener(
                 .add(format.prefix)
                 .add(format.groups)
                 .add(" ") { it.color = ChatColor.RESET }
-                .add(TextComponent.fromLegacyText(sender.displayName))
+                .add(TextComponent.fromLegacyText(senderDisplayName))
                 .add(format.suffix)
                 .add(": ") { it.color = ChatColor.RESET }
                 .add(TextComponent.fromLegacyText(message))


### PR DESCRIPTION
`player.displayName` has to be sent from a Spigot server, as `Essentials` (or whatever other plugin that formats nicknames) is not present on the Proxy server