### PR TITLE
Supress join/leave messages when switching servers

### DIFF
--- a/src/main/kotlin/com/projectcitybuild/features/chat/commands/ReplyCommand.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/chat/commands/ReplyCommand.kt
@@ -19,7 +19,7 @@ class ReplyCommand(
 
     override val label = "reply"
     override val aliases = arrayOf("r")
-    override val permission = "pcbridge.chat.reply"
+    override val permission = "pcbridge.chat.whisper"
     override val usageHelp = "/reply <message>"
 
     override suspend fun execute(input: BungeecordCommandInput) {

--- a/src/main/kotlin/com/projectcitybuild/features/joinmessage/JoinMessageModule.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/joinmessage/JoinMessageModule.kt
@@ -1,0 +1,23 @@
+package com.projectcitybuild.features.joinmessage
+
+import com.projectcitybuild.core.contracts.BungeecordFeatureModule
+import com.projectcitybuild.core.contracts.SpigotFeatureModule
+import com.projectcitybuild.features.joinmessage.listeners.NetworkJoinMessageListener
+import com.projectcitybuild.features.joinmessage.listeners.SupressJoinMessageListener
+import net.md_5.bungee.api.ProxyServer
+import net.md_5.bungee.api.plugin.Listener
+
+class JoinMessageModule {
+
+    class Bungee(proxyServer: ProxyServer): BungeecordFeatureModule {
+        override val bungeecordListeners: Array<Listener> = arrayOf(
+            NetworkJoinMessageListener(proxyServer),
+        )
+    }
+
+    class Spigot: SpigotFeatureModule {
+        override val spigotListeners: Array<org.bukkit.event.Listener> = arrayOf(
+            SupressJoinMessageListener(),
+        )
+    }
+}

--- a/src/main/kotlin/com/projectcitybuild/features/joinmessage/listeners/NetworkJoinMessageListener.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/joinmessage/listeners/NetworkJoinMessageListener.kt
@@ -1,0 +1,58 @@
+package com.projectcitybuild.features.joinmessage.listeners
+
+import com.projectcitybuild.platforms.bungeecord.extensions.add
+import net.md_5.bungee.api.ChatColor
+import net.md_5.bungee.api.ProxyServer
+import net.md_5.bungee.api.chat.TextComponent
+import net.md_5.bungee.api.event.PlayerDisconnectEvent
+import net.md_5.bungee.api.event.PostLoginEvent
+import net.md_5.bungee.api.event.ServerSwitchEvent
+import net.md_5.bungee.api.plugin.Listener
+import net.md_5.bungee.event.EventHandler
+
+class NetworkJoinMessageListener(
+    private val proxyServer: ProxyServer
+): Listener {
+
+    @EventHandler
+    fun onPostLoginEvent(event: PostLoginEvent) {
+        proxyServer.broadcast(
+            TextComponent()
+                .add("+ ") {
+                    it.color = ChatColor.GREEN
+                    it.isBold = true
+                }
+                .add(event.player.name) { it.color = ChatColor.WHITE }
+                .add(" joined the server") { it.color = ChatColor.GRAY }
+        )
+    }
+
+    @EventHandler
+    fun onPlayerDisconnectEvent(event: PlayerDisconnectEvent) {
+        proxyServer.broadcast(
+            TextComponent()
+                .add("— ") {
+                    it.color = ChatColor.RED
+                    it.isBold = true
+                }
+                .add(event.player.name) { it.color = ChatColor.WHITE }
+                .add(" left the server") { it.color = ChatColor.GRAY }
+        )
+    }
+
+    @EventHandler
+    fun onServerSwitchEvent(event: ServerSwitchEvent) {
+        if (event.from == null) return
+
+        proxyServer.broadcast(
+            TextComponent()
+                .add("⇒ ") {
+                    it.color = ChatColor.YELLOW
+                    it.isBold = true
+                }
+                .add(event.player.name) { it.color = ChatColor.WHITE }
+                .add(" switched to ") { it.color = ChatColor.GRAY }
+                .add(event.player.server.info.name) { it.color = ChatColor.WHITE }
+        )
+    }
+}

--- a/src/main/kotlin/com/projectcitybuild/features/joinmessage/listeners/SupressJoinMessageListener.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/joinmessage/listeners/SupressJoinMessageListener.kt
@@ -1,0 +1,23 @@
+package com.projectcitybuild.features.joinmessage.listeners
+
+import org.bukkit.event.EventHandler
+import org.bukkit.event.Listener
+import org.bukkit.event.player.PlayerJoinEvent
+import org.bukkit.event.player.PlayerQuitEvent
+
+class SupressJoinMessageListener: Listener {
+
+    @EventHandler
+    fun onPlayerJoin(event: PlayerJoinEvent) {
+        // Supress join messages on Spigot servers because only the
+        // Bungeecord server knows when a player joins the network
+        event.joinMessage = null
+    }
+
+    @EventHandler
+    fun onPlayerLeave(event: PlayerQuitEvent) {
+        // Supress quit messages on Spigot servers because only the
+        // Bungeecord server knows when a player leaves the network
+        event.quitMessage = null
+    }
+}

--- a/src/main/kotlin/com/projectcitybuild/platforms/bungeecord/BungeecordPlatform.kt
+++ b/src/main/kotlin/com/projectcitybuild/platforms/bungeecord/BungeecordPlatform.kt
@@ -17,6 +17,7 @@ import com.projectcitybuild.features.hub.listeners.IncomingSetHubListener
 import com.projectcitybuild.modules.permissions.PermissionsManager
 import com.projectcitybuild.features.bans.repositories.BanRepository
 import com.projectcitybuild.features.chat.ChatGroupFormatBuilder
+import com.projectcitybuild.features.joinmessage.JoinMessageModule
 import com.projectcitybuild.old_modules.playerconfig.PlayerConfigCache
 import com.projectcitybuild.old_modules.playerconfig.PlayerConfigFileStorage
 import com.projectcitybuild.modules.playeruuid.MojangPlayerRepository
@@ -140,6 +141,7 @@ class BungeecordPlatform: Plugin() {
             BanModule(proxy, playerUUIDRepository, banRepository, bungeecordLogger),
             ChatModule.Bungeecord(proxy, playerUUIDRepository, playerConfigRepository, chatGroupFormatBuilder, sessionCache!!),
             HubModule.Bungeecord(proxy, hubFileStorage),
+            JoinMessageModule.Bungee(proxy),
             RankSyncModule(proxy, apiRequestFactory, apiClient, syncPlayerGroupService),
             TeleportModule.Bungeecord(proxy, playerConfigRepository),
             WarpModule.Bungeecord(proxy, warpFileStorage),

--- a/src/main/kotlin/com/projectcitybuild/platforms/spigot/SpigotPlatform.kt
+++ b/src/main/kotlin/com/projectcitybuild/platforms/spigot/SpigotPlatform.kt
@@ -12,6 +12,7 @@ import com.projectcitybuild.features.warps.WarpModule
 import com.projectcitybuild.modules.sessioncache.SpigotSessionCache
 import com.projectcitybuild.platforms.spigot.environment.*
 import com.projectcitybuild.features.chat.ChatModule
+import com.projectcitybuild.features.joinmessage.JoinMessageModule
 import com.projectcitybuild.features.teleporting.TeleportModule
 import com.projectcitybuild.modules.channels.SpigotMessageListener
 import com.projectcitybuild.modules.config.implementations.SpigotConfig
@@ -69,6 +70,7 @@ class SpigotPlatform: JavaPlugin() {
         arrayOf(
             ChatModule.Spigot(plugin = this),
             HubModule.Spigot(plugin = this),
+            JoinMessageModule.Spigot(),
             TeleportModule.Spigot(plugin = this, spigotLogger, spigotSessionCache!!),
             WarpModule.Spigot(plugin = this, spigotLogger, spigotSessionCache!!),
         )


### PR DESCRIPTION
Only shows "XXX joined/left the server" message if the player joins/leaves the network.
Switching servers now shows a "XXX switched to YYY" instead of a join/leave message.

Fixes #46