### PR TITLE
Clean up

### DIFF
--- a/src/main/kotlin/com/projectcitybuild/core/InvalidCommandArgumentsException.kt
+++ b/src/main/kotlin/com/projectcitybuild/core/InvalidCommandArgumentsException.kt
@@ -1,0 +1,3 @@
+package com.projectcitybuild.core
+
+class InvalidCommandArgumentsException: Exception()

--- a/src/main/kotlin/com/projectcitybuild/core/ListenerTypealias.kt
+++ b/src/main/kotlin/com/projectcitybuild/core/ListenerTypealias.kt
@@ -1,0 +1,4 @@
+package com.projectcitybuild.core
+
+typealias SpigotListener = org.bukkit.event.Listener
+typealias BungeecordListener = net.md_5.bungee.api.plugin.Listener

--- a/src/main/kotlin/com/projectcitybuild/core/contracts/FeatureModule.kt
+++ b/src/main/kotlin/com/projectcitybuild/core/contracts/FeatureModule.kt
@@ -2,7 +2,8 @@ package com.projectcitybuild.core.contracts
 
 import com.projectcitybuild.core.BungeecordListener
 import com.projectcitybuild.core.SpigotListener
-import com.projectcitybuild.modules.channels.SubChannelListener
+import com.projectcitybuild.modules.channels.bungeecord.BungeecordSubChannelListener
+import com.projectcitybuild.modules.channels.spigot.SpigotSubChannelListener
 import com.projectcitybuild.platforms.bungeecord.environment.BungeecordCommand
 import com.projectcitybuild.platforms.spigot.environment.SpigotCommand
 
@@ -12,6 +13,9 @@ interface BungeecordFeatureModule {
         get() = emptyArray()
 
     val bungeecordListeners: Array<BungeecordListener>
+        get() = emptyArray()
+
+    val bungeecordSubChannelListeners: Array<BungeecordSubChannelListener>
         get() = emptyArray()
 }
 
@@ -23,6 +27,6 @@ interface SpigotFeatureModule {
     val spigotListeners: Array<SpigotListener>
         get() = emptyArray()
 
-    val spigotSubChannelListeners: HashMap<String, SubChannelListener>
-        get() = HashMap()
+    val spigotSubChannelListeners: Array<SpigotSubChannelListener>
+        get() = emptyArray()
 }

--- a/src/main/kotlin/com/projectcitybuild/core/contracts/FeatureModule.kt
+++ b/src/main/kotlin/com/projectcitybuild/core/contracts/FeatureModule.kt
@@ -1,10 +1,10 @@
 package com.projectcitybuild.core.contracts
 
+import com.projectcitybuild.core.BungeecordListener
+import com.projectcitybuild.core.SpigotListener
 import com.projectcitybuild.modules.channels.SubChannelListener
 import com.projectcitybuild.platforms.bungeecord.environment.BungeecordCommand
 import com.projectcitybuild.platforms.spigot.environment.SpigotCommand
-import org.bukkit.event.Listener as SpigotListener
-import net.md_5.bungee.api.plugin.Listener as BungeecordListener
 
 interface BungeecordFeatureModule {
 

--- a/src/main/kotlin/com/projectcitybuild/features/afk/commands/AFKCommand.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/afk/commands/AFKCommand.kt
@@ -1,5 +1,6 @@
 package com.projectcitybuild.features.afk.commands
 
+import com.projectcitybuild.core.InvalidCommandArgumentsException
 import com.projectcitybuild.platforms.bungeecord.environment.BungeecordCommand
 import com.projectcitybuild.platforms.bungeecord.environment.BungeecordCommandInput
 import com.projectcitybuild.modules.textcomponentbuilder.send
@@ -21,8 +22,7 @@ class AFKCommand(
 
     override suspend fun execute(input: BungeecordCommandInput) {
         if (input.args.isNotEmpty()) {
-            input.sender.send().invalidCommandInput(this)
-            return
+            throw InvalidCommandArgumentsException()
         }
         if (input.isConsoleSender) {
             input.sender.send().error("Console cannot use this command")

--- a/src/main/kotlin/com/projectcitybuild/features/afk/listeners/AFKListener.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/afk/listeners/AFKListener.kt
@@ -1,5 +1,6 @@
 package com.projectcitybuild.features.afk.listeners
 
+import com.projectcitybuild.core.SpigotListener
 import com.projectcitybuild.entities.SubChannel
 import com.projectcitybuild.platforms.spigot.MessageToBungeecord
 import org.bukkit.entity.Player
@@ -17,7 +18,7 @@ import org.bukkit.plugin.Plugin
 
 class AFKListener(
     private val plugin: Plugin
-): Listener {
+): SpigotListener {
 
 //    @EventHandler(priority = EventPriority.LOW)
 //    fun onBlockBreak(event: BlockBreakEvent) {

--- a/src/main/kotlin/com/projectcitybuild/features/afk/listeners/IncomingAFKEndListener.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/afk/listeners/IncomingAFKEndListener.kt
@@ -1,6 +1,7 @@
 package com.projectcitybuild.features.afk.listeners
 
 import com.google.common.io.ByteStreams
+import com.projectcitybuild.core.SpigotListener
 import com.projectcitybuild.entities.Channel
 import com.projectcitybuild.entities.SubChannel
 import com.projectcitybuild.modules.sessioncache.SpigotSessionCache
@@ -9,13 +10,12 @@ import net.md_5.bungee.api.ProxyServer
 import net.md_5.bungee.api.chat.TextComponent
 import net.md_5.bungee.api.connection.ProxiedPlayer
 import net.md_5.bungee.api.event.PluginMessageEvent
-import net.md_5.bungee.api.plugin.Listener
 import net.md_5.bungee.event.EventHandler
 
 class IncomingAFKEndListener(
     private val proxy: ProxyServer,
     private val spigotSessionCache: SpigotSessionCache
-): Listener {
+): SpigotListener {
 
     @EventHandler
     fun onPluginMessageReceived(event: PluginMessageEvent) {

--- a/src/main/kotlin/com/projectcitybuild/features/bans/commands/BanCommand.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/bans/commands/BanCommand.kt
@@ -1,5 +1,6 @@
 package com.projectcitybuild.features.bans.commands
 
+import com.projectcitybuild.core.InvalidCommandArgumentsException
 import com.projectcitybuild.core.extensions.joinWithWhitespaces
 import com.projectcitybuild.features.bans.repositories.BanRepository
 import com.projectcitybuild.modules.textcomponentbuilder.send
@@ -23,8 +24,7 @@ class BanCommand(
 
     override suspend fun execute(input: BungeecordCommandInput) {
         if (input.args.isEmpty()) {
-            input.sender.send().invalidCommandInput(this)
-            return
+            throw InvalidCommandArgumentsException()
         }
 
         val staffPlayer = if (input.isConsoleSender) null else input.player

--- a/src/main/kotlin/com/projectcitybuild/features/bans/commands/CheckBanCommand.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/bans/commands/CheckBanCommand.kt
@@ -1,5 +1,6 @@
 package com.projectcitybuild.features.bans.commands
 
+import com.projectcitybuild.core.InvalidCommandArgumentsException
 import com.projectcitybuild.features.bans.repositories.BanRepository
 import com.projectcitybuild.modules.playeruuid.PlayerUUIDRepository
 import com.projectcitybuild.platforms.bungeecord.environment.BungeecordCommand
@@ -23,8 +24,7 @@ class CheckBanCommand(
 
     override suspend fun execute(input: BungeecordCommandInput) {
         if (input.args.size != 1) {
-            input.sender.send().invalidCommandInput(this)
-            return
+            throw InvalidCommandArgumentsException()
         }
 
         val targetPlayerName = input.args.first()

--- a/src/main/kotlin/com/projectcitybuild/features/bans/commands/UnbanCommand.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/bans/commands/UnbanCommand.kt
@@ -1,5 +1,6 @@
 package com.projectcitybuild.features.bans.commands
 
+import com.projectcitybuild.core.InvalidCommandArgumentsException
 import com.projectcitybuild.features.bans.repositories.BanRepository
 import com.projectcitybuild.modules.playeruuid.PlayerUUIDRepository
 import com.projectcitybuild.platforms.bungeecord.environment.BungeecordCommand
@@ -22,8 +23,7 @@ class UnbanCommand(
 
     override suspend fun execute(input: BungeecordCommandInput) {
         if (input.args.size != 1) {
-            input.sender.send().invalidCommandInput(this)
-            return
+            throw InvalidCommandArgumentsException()
         }
 
         val targetPlayerName = input.args.first()

--- a/src/main/kotlin/com/projectcitybuild/features/bans/listeners/BanConnectionListener.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/bans/listeners/BanConnectionListener.kt
@@ -1,5 +1,6 @@
 package com.projectcitybuild.features.bans.listeners
 
+import com.projectcitybuild.core.BungeecordListener
 import com.projectcitybuild.modules.logger.LoggerProvider
 import com.projectcitybuild.features.bans.repositories.BanRepository
 import com.projectcitybuild.platforms.bungeecord.extensions.add
@@ -7,14 +8,13 @@ import kotlinx.coroutines.runBlocking
 import net.md_5.bungee.api.ChatColor
 import net.md_5.bungee.api.chat.TextComponent
 import net.md_5.bungee.api.event.LoginEvent
-import net.md_5.bungee.api.plugin.Listener
 import net.md_5.bungee.event.EventHandler
 import net.md_5.bungee.event.EventPriority
 
 class BanConnectionListener(
     private val banRepository: BanRepository,
     private val logger: LoggerProvider
-) : Listener {
+) : BungeecordListener {
 
     // This event is actually asynchronous, so despite the naming
     // this should not be blocking

--- a/src/main/kotlin/com/projectcitybuild/features/chat/ChatModule.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/chat/ChatModule.kt
@@ -4,13 +4,13 @@ import com.projectcitybuild.core.contracts.BungeecordFeatureModule
 import com.projectcitybuild.core.contracts.SpigotFeatureModule
 import com.projectcitybuild.features.chat.commands.*
 import com.projectcitybuild.features.chat.listeners.ChatListener
-import com.projectcitybuild.features.chat.listeners.IncomingChatListener
+import com.projectcitybuild.features.chat.subchannels.IncomingChatChannelListener
+import com.projectcitybuild.modules.channels.bungeecord.BungeecordSubChannelListener
 import com.projectcitybuild.platforms.bungeecord.environment.BungeecordCommand
 import com.projectcitybuild.old_modules.playerconfig.PlayerConfigRepository
 import com.projectcitybuild.modules.playeruuid.PlayerUUIDRepository
 import com.projectcitybuild.modules.sessioncache.BungeecordSessionCache
 import net.md_5.bungee.api.ProxyServer
-import net.md_5.bungee.api.plugin.Listener
 import org.bukkit.plugin.Plugin
 import org.bukkit.event.Listener as SpigotListener
 
@@ -34,8 +34,8 @@ class ChatModule {
             WhisperCommand(proxyServer, playerConfigRepository, sessionCache),
         )
 
-        override val bungeecordListeners: Array<Listener> = arrayOf(
-            IncomingChatListener(proxyServer, playerConfigRepository, chatGroupFormatBuilder)
+        override val bungeecordSubChannelListeners: Array<BungeecordSubChannelListener> = arrayOf(
+            IncomingChatChannelListener(proxyServer, playerConfigRepository, chatGroupFormatBuilder)
         )
     }
 

--- a/src/main/kotlin/com/projectcitybuild/features/chat/commands/ACommand.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/chat/commands/ACommand.kt
@@ -1,5 +1,6 @@
 package com.projectcitybuild.features.chat.commands
 
+import com.projectcitybuild.core.InvalidCommandArgumentsException
 import com.projectcitybuild.platforms.bungeecord.environment.BungeecordCommand
 import com.projectcitybuild.platforms.bungeecord.environment.BungeecordCommandInput
 import com.projectcitybuild.platforms.bungeecord.extensions.add
@@ -19,8 +20,7 @@ class ACommand(
 
     override suspend fun execute(input: BungeecordCommandInput) {
         if (input.args.isEmpty()) {
-            input.sender.send().invalidCommandInput(this)
-            return
+            throw InvalidCommandArgumentsException()
         }
 
         val message = input.args.joinToString(separator = " ")

--- a/src/main/kotlin/com/projectcitybuild/features/chat/commands/IgnoreCommand.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/chat/commands/IgnoreCommand.kt
@@ -1,5 +1,6 @@
 package com.projectcitybuild.features.chat.commands
 
+import com.projectcitybuild.core.InvalidCommandArgumentsException
 import com.projectcitybuild.old_modules.playerconfig.PlayerConfigRepository
 import com.projectcitybuild.modules.playeruuid.PlayerUUIDRepository
 import com.projectcitybuild.old_modules.storage.SerializableUUID
@@ -21,8 +22,7 @@ class IgnoreCommand(
 
     override suspend fun execute(input: BungeecordCommandInput) {
         if (input.args.size != 1) {
-            input.sender.send().invalidCommandInput(this)
-            return
+            throw InvalidCommandArgumentsException()
         }
 
         val targetPlayerName = input.args.first()

--- a/src/main/kotlin/com/projectcitybuild/features/chat/commands/MuteCommand.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/chat/commands/MuteCommand.kt
@@ -1,5 +1,6 @@
 package com.projectcitybuild.features.chat.commands
 
+import com.projectcitybuild.core.InvalidCommandArgumentsException
 import com.projectcitybuild.old_modules.playerconfig.PlayerConfigRepository
 import com.projectcitybuild.platforms.bungeecord.environment.BungeecordCommand
 import com.projectcitybuild.platforms.bungeecord.environment.BungeecordCommandInput
@@ -18,8 +19,7 @@ class MuteCommand(
 
     override suspend fun execute(input: BungeecordCommandInput) {
         if (input.args.size != 1) {
-            input.sender.send().invalidCommandInput(this)
-            return
+            throw InvalidCommandArgumentsException()
         }
 
         val targetPlayerName = input.args.first()

--- a/src/main/kotlin/com/projectcitybuild/features/chat/commands/ReplyCommand.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/chat/commands/ReplyCommand.kt
@@ -1,5 +1,6 @@
 package com.projectcitybuild.features.chat.commands
 
+import com.projectcitybuild.core.InvalidCommandArgumentsException
 import com.projectcitybuild.core.extensions.joinWithWhitespaces
 import com.projectcitybuild.modules.sessioncache.BungeecordSessionCache
 import com.projectcitybuild.platforms.bungeecord.environment.BungeecordCommand
@@ -28,8 +29,7 @@ class ReplyCommand(
             return
         }
         if (input.args.isEmpty()) {
-            input.sender.send().invalidCommandInput(this)
-            return
+            throw InvalidCommandArgumentsException()
         }
 
         val playerWhoLastWhispered = sessionCache.lastWhispered[input.player.uniqueId]

--- a/src/main/kotlin/com/projectcitybuild/features/chat/commands/UnignoreCommand.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/chat/commands/UnignoreCommand.kt
@@ -1,5 +1,6 @@
 package com.projectcitybuild.features.chat.commands
 
+import com.projectcitybuild.core.InvalidCommandArgumentsException
 import com.projectcitybuild.old_modules.playerconfig.PlayerConfigRepository
 import com.projectcitybuild.modules.playeruuid.PlayerUUIDRepository
 import com.projectcitybuild.platforms.bungeecord.environment.BungeecordCommand
@@ -20,8 +21,7 @@ class UnignoreCommand(
 
     override suspend fun execute(input: BungeecordCommandInput) {
         if (input.args.size != 1) {
-            input.sender.send().invalidCommandInput(this)
-            return
+            throw InvalidCommandArgumentsException()
         }
 
         val targetPlayerName = input.args.first()

--- a/src/main/kotlin/com/projectcitybuild/features/chat/commands/UnmuteCommand.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/chat/commands/UnmuteCommand.kt
@@ -1,5 +1,6 @@
 package com.projectcitybuild.features.chat.commands
 
+import com.projectcitybuild.core.InvalidCommandArgumentsException
 import com.projectcitybuild.old_modules.playerconfig.PlayerConfigRepository
 import com.projectcitybuild.platforms.bungeecord.environment.BungeecordCommand
 import com.projectcitybuild.platforms.bungeecord.environment.BungeecordCommandInput
@@ -18,8 +19,7 @@ class UnmuteCommand(
 
     override suspend fun execute(input: BungeecordCommandInput) {
         if (input.args.size != 1) {
-            input.sender.send().invalidCommandInput(this)
-            return
+            throw InvalidCommandArgumentsException()
         }
 
         val targetPlayerName = input.args.first()

--- a/src/main/kotlin/com/projectcitybuild/features/chat/commands/WhisperCommand.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/chat/commands/WhisperCommand.kt
@@ -1,5 +1,6 @@
 package com.projectcitybuild.features.chat.commands
 
+import com.projectcitybuild.core.InvalidCommandArgumentsException
 import com.projectcitybuild.core.extensions.joinWithWhitespaces
 import com.projectcitybuild.modules.sessioncache.BungeecordSessionCache
 import com.projectcitybuild.old_modules.playerconfig.PlayerConfigRepository
@@ -24,8 +25,7 @@ class WhisperCommand(
 
     override suspend fun execute(input: BungeecordCommandInput) {
         if (input.args.isEmpty()) {
-            input.sender.send().invalidCommandInput(this)
-            return
+            throw InvalidCommandArgumentsException()
         }
         val targetPlayerName = input.args.first()
 

--- a/src/main/kotlin/com/projectcitybuild/features/chat/listeners/ChatListener.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/chat/listeners/ChatListener.kt
@@ -1,16 +1,16 @@
 package com.projectcitybuild.features.chat.listeners
 
+import com.projectcitybuild.core.SpigotListener
 import com.projectcitybuild.entities.SubChannel
 import com.projectcitybuild.platforms.spigot.MessageToBungeecord
 import org.bukkit.event.EventHandler
 import org.bukkit.event.EventPriority
-import org.bukkit.event.Listener
 import org.bukkit.event.player.AsyncPlayerChatEvent
 import org.bukkit.plugin.Plugin
 
 class ChatListener(
     private val plugin: Plugin
-): Listener {
+): SpigotListener {
 
     @EventHandler(priority = EventPriority.HIGHEST)
     fun onAsyncPlayerChatEvent(event: AsyncPlayerChatEvent) {

--- a/src/main/kotlin/com/projectcitybuild/features/hub/HubModule.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/hub/HubModule.kt
@@ -4,12 +4,12 @@ import com.projectcitybuild.core.contracts.BungeecordFeatureModule
 import com.projectcitybuild.core.contracts.SpigotFeatureModule
 import com.projectcitybuild.features.hub.commands.HubCommand
 import com.projectcitybuild.features.hub.commands.SetHubCommand
-import com.projectcitybuild.features.hub.listeners.IncomingSetHubListener
+import com.projectcitybuild.features.hub.subchannels.IncomingSetHubListener
+import com.projectcitybuild.modules.channels.bungeecord.BungeecordSubChannelListener
 import com.projectcitybuild.platforms.bungeecord.environment.BungeecordCommand
 import com.projectcitybuild.old_modules.storage.HubFileStorage
 import com.projectcitybuild.platforms.spigot.environment.SpigotCommand
 import net.md_5.bungee.api.ProxyServer
-import net.md_5.bungee.api.plugin.Listener
 import org.bukkit.plugin.Plugin
 
 class HubModule {
@@ -22,7 +22,7 @@ class HubModule {
             HubCommand(proxyServer, hubFileStorage),
         )
 
-        override val bungeecordListeners: Array<Listener> = arrayOf(
+        override val bungeecordSubChannelListeners: Array<BungeecordSubChannelListener> = arrayOf(
             IncomingSetHubListener(hubFileStorage),
         )
     }

--- a/src/main/kotlin/com/projectcitybuild/features/hub/commands/HubCommand.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/hub/commands/HubCommand.kt
@@ -1,5 +1,6 @@
 package com.projectcitybuild.features.hub.commands
 
+import com.projectcitybuild.core.InvalidCommandArgumentsException
 import com.projectcitybuild.entities.SubChannel
 import com.projectcitybuild.old_modules.storage.HubFileStorage
 import com.projectcitybuild.platforms.bungeecord.MessageToSpigot
@@ -20,8 +21,7 @@ class HubCommand(
 
     override suspend fun execute(input: BungeecordCommandInput) {
         if (input.args.isNotEmpty()) {
-            input.sender.send().invalidCommandInput(this)
-            return
+            throw InvalidCommandArgumentsException()
         }
         if (input.player == null) {
             input.sender.send().error("Console cannot use this command")

--- a/src/main/kotlin/com/projectcitybuild/features/hub/commands/SetHubCommand.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/hub/commands/SetHubCommand.kt
@@ -1,10 +1,10 @@
 package com.projectcitybuild.features.hub.commands
 
+import com.projectcitybuild.core.InvalidCommandArgumentsException
 import com.projectcitybuild.platforms.spigot.environment.SpigotCommandInput
 import com.projectcitybuild.entities.SubChannel
 import com.projectcitybuild.modules.textcomponentbuilder.send
 import com.projectcitybuild.platforms.spigot.MessageToBungeecord
-import com.projectcitybuild.platforms.spigot.environment.CommandResult
 import com.projectcitybuild.platforms.spigot.environment.SpigotCommand
 import org.bukkit.entity.Player
 import org.bukkit.plugin.Plugin
@@ -13,17 +13,18 @@ class SetHubCommand(
     private val plugin: Plugin
 ): SpigotCommand {
 
-    override val label: String = "sethub"
+    override val label = "sethub"
     override val permission = "pcbridge.hub.set"
+    override val usageHelp = "/sethub"
 
-    override suspend fun execute(input: SpigotCommandInput): CommandResult {
+    override suspend fun execute(input: SpigotCommandInput) {
         if (input.args.isNotEmpty()) {
-            return CommandResult.INVALID_INPUT
+            throw InvalidCommandArgumentsException()
         }
         val player = input.sender as? Player
         if (player == null) {
             input.sender.send().error("Console cannot use this command")
-            return CommandResult.EXECUTED
+            return
         }
 
         MessageToBungeecord(
@@ -39,7 +40,5 @@ class SetHubCommand(
                 player.location.yaw,
             )
         ).send()
-
-        return CommandResult.EXECUTED
     }
 }

--- a/src/main/kotlin/com/projectcitybuild/features/joinmessage/listeners/NetworkJoinMessageListener.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/joinmessage/listeners/NetworkJoinMessageListener.kt
@@ -42,6 +42,7 @@ class NetworkJoinMessageListener(
 
     @EventHandler
     fun onServerSwitchEvent(event: ServerSwitchEvent) {
+        // Joining the network also sends a ServerSwitchEvent
         if (event.from == null) return
 
         proxyServer.broadcast(

--- a/src/main/kotlin/com/projectcitybuild/features/joinmessage/listeners/NetworkJoinMessageListener.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/joinmessage/listeners/NetworkJoinMessageListener.kt
@@ -1,5 +1,6 @@
 package com.projectcitybuild.features.joinmessage.listeners
 
+import com.projectcitybuild.core.BungeecordListener
 import com.projectcitybuild.platforms.bungeecord.extensions.add
 import net.md_5.bungee.api.ChatColor
 import net.md_5.bungee.api.ProxyServer
@@ -7,12 +8,11 @@ import net.md_5.bungee.api.chat.TextComponent
 import net.md_5.bungee.api.event.PlayerDisconnectEvent
 import net.md_5.bungee.api.event.PostLoginEvent
 import net.md_5.bungee.api.event.ServerSwitchEvent
-import net.md_5.bungee.api.plugin.Listener
 import net.md_5.bungee.event.EventHandler
 
 class NetworkJoinMessageListener(
     private val proxyServer: ProxyServer
-): Listener {
+): BungeecordListener {
 
     @EventHandler
     fun onPostLoginEvent(event: PostLoginEvent) {

--- a/src/main/kotlin/com/projectcitybuild/features/joinmessage/listeners/SupressJoinMessageListener.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/joinmessage/listeners/SupressJoinMessageListener.kt
@@ -1,11 +1,11 @@
 package com.projectcitybuild.features.joinmessage.listeners
 
+import com.projectcitybuild.core.SpigotListener
 import org.bukkit.event.EventHandler
-import org.bukkit.event.Listener
 import org.bukkit.event.player.PlayerJoinEvent
 import org.bukkit.event.player.PlayerQuitEvent
 
-class SupressJoinMessageListener: Listener {
+class SupressJoinMessageListener: SpigotListener {
 
     @EventHandler
     fun onPlayerJoin(event: PlayerJoinEvent) {

--- a/src/main/kotlin/com/projectcitybuild/features/ranksync/commands/SyncCommand.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/ranksync/commands/SyncCommand.kt
@@ -1,5 +1,6 @@
 package com.projectcitybuild.features.ranksync.commands
 
+import com.projectcitybuild.core.InvalidCommandArgumentsException
 import com.projectcitybuild.modules.network.APIRequestFactory
 import com.projectcitybuild.modules.network.APIClient
 import com.projectcitybuild.features.ranksync.SyncPlayerGroupService
@@ -31,7 +32,7 @@ class SyncCommand(
             syncGroups(input.sender as ProxiedPlayer)
         }
         else {
-            input.sender.send().invalidCommandInput(this)
+            throw InvalidCommandArgumentsException()
         }
     }
 

--- a/src/main/kotlin/com/projectcitybuild/features/ranksync/commands/SyncOtherCommand.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/ranksync/commands/SyncOtherCommand.kt
@@ -1,5 +1,6 @@
 package com.projectcitybuild.features.ranksync.commands
 
+import com.projectcitybuild.core.InvalidCommandArgumentsException
 import com.projectcitybuild.features.ranksync.SyncPlayerGroupService
 import com.projectcitybuild.platforms.bungeecord.environment.BungeecordCommand
 import com.projectcitybuild.platforms.bungeecord.environment.BungeecordCommandInput
@@ -18,8 +19,7 @@ class SyncOtherCommand(
 
     override suspend fun execute(input: BungeecordCommandInput) {
         if (input.args.size != 1) {
-            input.sender.send().invalidCommandInput(this)
-            return
+            throw InvalidCommandArgumentsException()
         }
 
         val playerName = input.args.first()

--- a/src/main/kotlin/com/projectcitybuild/features/ranksync/listeners/SyncRankLoginListener.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/ranksync/listeners/SyncRankLoginListener.kt
@@ -1,17 +1,17 @@
 package com.projectcitybuild.features.ranksync.listeners
 
+import com.projectcitybuild.core.BungeecordListener
 import com.projectcitybuild.features.ranksync.SyncPlayerGroupService
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import net.md_5.bungee.api.event.PostLoginEvent
-import net.md_5.bungee.api.plugin.Listener
 import net.md_5.bungee.event.EventHandler
 import net.md_5.bungee.event.EventPriority
 
 class SyncRankLoginListener(
     private val syncPlayerGroupService: SyncPlayerGroupService
-): Listener {
+): BungeecordListener {
 
     @EventHandler(priority = EventPriority.HIGHEST)
     fun onPlayerJoin(event: PostLoginEvent) {

--- a/src/main/kotlin/com/projectcitybuild/features/teleporting/TeleportModule.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/teleporting/TeleportModule.kt
@@ -2,7 +2,6 @@ package com.projectcitybuild.features.teleporting
 
 import com.projectcitybuild.core.contracts.BungeecordFeatureModule
 import com.projectcitybuild.core.contracts.SpigotFeatureModule
-import com.projectcitybuild.entities.SubChannel
 import com.projectcitybuild.platforms.bungeecord.environment.BungeecordCommand
 import com.projectcitybuild.features.teleporting.commands.TPCommand
 import com.projectcitybuild.features.teleporting.commands.TPHereCommand
@@ -10,7 +9,7 @@ import com.projectcitybuild.features.teleporting.commands.TPOCommand
 import com.projectcitybuild.features.teleporting.commands.TPToggleCommand
 import com.projectcitybuild.features.teleporting.subchannels.AwaitJoinTeleportChannelListener
 import com.projectcitybuild.features.teleporting.subchannels.ImmediateTeleportChannelListener
-import com.projectcitybuild.modules.channels.SubChannelListener
+import com.projectcitybuild.modules.channels.spigot.SpigotSubChannelListener
 import com.projectcitybuild.modules.logger.LoggerProvider
 import com.projectcitybuild.modules.sessioncache.SpigotSessionCache
 import com.projectcitybuild.old_modules.playerconfig.PlayerConfigRepository
@@ -36,9 +35,9 @@ class TeleportModule {
         logger: LoggerProvider,
         spigotSessionCache: SpigotSessionCache
     ): SpigotFeatureModule {
-        override val spigotSubChannelListeners: HashMap<String, SubChannelListener> = hashMapOf(
-            Pair(SubChannel.TP_AWAIT_JOIN, AwaitJoinTeleportChannelListener(plugin, logger, spigotSessionCache)),
-            Pair(SubChannel.TP_IMMEDIATELY, ImmediateTeleportChannelListener(plugin, logger)),
+        override val spigotSubChannelListeners: Array<SpigotSubChannelListener> = arrayOf(
+            AwaitJoinTeleportChannelListener(plugin, logger, spigotSessionCache),
+            ImmediateTeleportChannelListener(plugin, logger),
         )
     }
 }

--- a/src/main/kotlin/com/projectcitybuild/features/teleporting/commands/TPCommand.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/teleporting/commands/TPCommand.kt
@@ -1,5 +1,6 @@
 package com.projectcitybuild.features.teleporting.commands
 
+import com.projectcitybuild.core.InvalidCommandArgumentsException
 import com.projectcitybuild.entities.SubChannel
 import com.projectcitybuild.old_modules.playerconfig.PlayerConfigRepository
 import com.projectcitybuild.platforms.bungeecord.MessageToSpigot
@@ -24,8 +25,7 @@ class TPCommand(
             return
         }
         if (input.args.size != 1) {
-            input.sender.send().invalidCommandInput(this)
-            return
+            throw InvalidCommandArgumentsException()
         }
 
         val targetPlayerName = input.args.first()

--- a/src/main/kotlin/com/projectcitybuild/features/teleporting/commands/TPHereCommand.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/teleporting/commands/TPHereCommand.kt
@@ -1,5 +1,6 @@
 package com.projectcitybuild.features.teleporting.commands
 
+import com.projectcitybuild.core.InvalidCommandArgumentsException
 import com.projectcitybuild.entities.SubChannel
 import com.projectcitybuild.platforms.bungeecord.MessageToSpigot
 import com.projectcitybuild.platforms.bungeecord.environment.BungeecordCommand
@@ -22,8 +23,7 @@ class TPHereCommand(
             return
         }
         if (input.args.size != 1) {
-            input.sender.send().invalidCommandInput(this)
-            return
+            throw InvalidCommandArgumentsException()
         }
 
         val targetPlayerName = input.args.first()

--- a/src/main/kotlin/com/projectcitybuild/features/teleporting/commands/TPOCommand.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/teleporting/commands/TPOCommand.kt
@@ -1,5 +1,6 @@
 package com.projectcitybuild.features.teleporting.commands
 
+import com.projectcitybuild.core.InvalidCommandArgumentsException
 import com.projectcitybuild.entities.SubChannel
 import com.projectcitybuild.platforms.bungeecord.MessageToSpigot
 import com.projectcitybuild.platforms.bungeecord.environment.BungeecordCommand
@@ -22,8 +23,7 @@ class TPOCommand(
             return
         }
         if (input.args.size != 1) {
-            input.sender.send().invalidCommandInput(this)
-            return
+            throw InvalidCommandArgumentsException()
         }
 
         val targetPlayerName = input.args.first()

--- a/src/main/kotlin/com/projectcitybuild/features/teleporting/commands/TPToggleCommand.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/teleporting/commands/TPToggleCommand.kt
@@ -1,5 +1,6 @@
 package com.projectcitybuild.features.teleporting.commands
 
+import com.projectcitybuild.core.InvalidCommandArgumentsException
 import com.projectcitybuild.old_modules.playerconfig.PlayerConfigRepository
 import com.projectcitybuild.platforms.bungeecord.environment.BungeecordCommand
 import com.projectcitybuild.platforms.bungeecord.environment.BungeecordCommandInput
@@ -25,8 +26,7 @@ class TPToggleCommand(
             input.args.size != 1
                     || input.args.first().lowercase() != "off"
                     || input.args.first().lowercase() != "on" -> {
-                input.sender.send().invalidCommandInput(this)
-                return
+                throw InvalidCommandArgumentsException()
             }
         }
 

--- a/src/main/kotlin/com/projectcitybuild/features/teleporting/subchannels/AwaitJoinTeleportChannelListener.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/teleporting/subchannels/AwaitJoinTeleportChannelListener.kt
@@ -1,7 +1,8 @@
 package com.projectcitybuild.features.teleporting.subchannels
 
 import com.google.common.io.ByteArrayDataInput
-import com.projectcitybuild.modules.channels.SubChannelListener
+import com.projectcitybuild.entities.SubChannel
+import com.projectcitybuild.modules.channels.spigot.SpigotSubChannelListener
 import com.projectcitybuild.modules.logger.LoggerProvider
 import com.projectcitybuild.modules.sessioncache.SpigotSessionCache
 import com.projectcitybuild.modules.textcomponentbuilder.send
@@ -13,9 +14,11 @@ class AwaitJoinTeleportChannelListener(
     private val plugin: Plugin,
     private val logger: LoggerProvider,
     private val spigotSessionCache: SpigotSessionCache
-): SubChannelListener {
+): SpigotSubChannelListener {
 
-    override fun onSpigotMessageReceived(player: Player?, stream: ByteArrayDataInput) {
+    override val subChannel = SubChannel.TP_AWAIT_JOIN
+
+    override fun onSpigotReceivedMessage(player: Player?, stream: ByteArrayDataInput) {
         val teleportingPlayerUUID = UUID.fromString(stream.readUTF())
         val teleportTargetPlayerUUID = UUID.fromString(stream.readUTF())
 

--- a/src/main/kotlin/com/projectcitybuild/features/teleporting/subchannels/ImmediateTeleportChannelListener.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/teleporting/subchannels/ImmediateTeleportChannelListener.kt
@@ -1,7 +1,8 @@
 package com.projectcitybuild.features.teleporting.subchannels
 
 import com.google.common.io.ByteArrayDataInput
-import com.projectcitybuild.modules.channels.SubChannelListener
+import com.projectcitybuild.entities.SubChannel
+import com.projectcitybuild.modules.channels.spigot.SpigotSubChannelListener
 import com.projectcitybuild.modules.logger.LoggerProvider
 import com.projectcitybuild.modules.textcomponentbuilder.send
 import org.bukkit.entity.Player
@@ -11,9 +12,11 @@ import java.util.*
 class ImmediateTeleportChannelListener(
     private val plugin: Plugin,
     private val logger: LoggerProvider
-): SubChannelListener {
+): SpigotSubChannelListener {
 
-    override fun onSpigotMessageReceived(player: Player?, stream: ByteArrayDataInput) {
+    override val subChannel = SubChannel.TP_IMMEDIATELY
+
+    override fun onSpigotReceivedMessage(player: Player?, stream: ByteArrayDataInput) {
         val teleportingPlayerUUID = UUID.fromString(stream.readUTF())
         val teleportTargetPlayerUUID = UUID.fromString(stream.readUTF())
 

--- a/src/main/kotlin/com/projectcitybuild/features/warps/WarpModule.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/warps/WarpModule.kt
@@ -8,16 +8,16 @@ import com.projectcitybuild.features.warps.commands.DelWarpCommand
 import com.projectcitybuild.features.warps.commands.SetWarpCommand
 import com.projectcitybuild.features.warps.commands.WarpCommand
 import com.projectcitybuild.features.warps.commands.WarpsCommand
-import com.projectcitybuild.features.warps.listeners.IncomingSetWarpListener
+import com.projectcitybuild.features.warps.subchannels.IncomingSetWarpListener
 import com.projectcitybuild.features.warps.subchannels.AwaitJoinWarpChannelListener
 import com.projectcitybuild.features.warps.subchannels.ImmediateWarpChannelListener
-import com.projectcitybuild.modules.channels.SubChannelListener
+import com.projectcitybuild.modules.channels.bungeecord.BungeecordSubChannelListener
+import com.projectcitybuild.modules.channels.spigot.SpigotSubChannelListener
 import com.projectcitybuild.modules.logger.LoggerProvider
 import com.projectcitybuild.modules.sessioncache.SpigotSessionCache
 import com.projectcitybuild.old_modules.storage.WarpFileStorage
 import com.projectcitybuild.platforms.spigot.environment.SpigotCommand
 import net.md_5.bungee.api.ProxyServer
-import net.md_5.bungee.api.plugin.Listener
 import org.bukkit.plugin.Plugin
 
 class WarpModule {
@@ -32,7 +32,7 @@ class WarpModule {
             WarpsCommand(warpFileStorage),
         )
 
-        override val bungeecordListeners: Array<Listener> = arrayOf(
+        override val bungeecordSubChannelListeners: Array<BungeecordSubChannelListener> = arrayOf(
             IncomingSetWarpListener(warpFileStorage),
         )
     }
@@ -46,9 +46,9 @@ class WarpModule {
             SetWarpCommand(plugin),
         )
 
-        override val spigotSubChannelListeners: HashMap<String, SubChannelListener> = hashMapOf(
-            Pair(SubChannel.WARP_AWAIT_JOIN, AwaitJoinWarpChannelListener(plugin, logger, spigotSessionCache)),
-            Pair(SubChannel.WARP_IMMEDIATELY, ImmediateWarpChannelListener(plugin, logger)),
+        override val spigotSubChannelListeners: Array<SpigotSubChannelListener> = arrayOf(
+            AwaitJoinWarpChannelListener(plugin, logger, spigotSessionCache),
+            ImmediateWarpChannelListener(plugin, logger),
         )
     }
 }

--- a/src/main/kotlin/com/projectcitybuild/features/warps/commands/DelWarpCommand.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/warps/commands/DelWarpCommand.kt
@@ -1,5 +1,6 @@
 package com.projectcitybuild.features.warps.commands
 
+import com.projectcitybuild.core.InvalidCommandArgumentsException
 import com.projectcitybuild.old_modules.storage.WarpFileStorage
 import com.projectcitybuild.platforms.bungeecord.environment.BungeecordCommand
 import com.projectcitybuild.platforms.bungeecord.environment.BungeecordCommandInput
@@ -16,8 +17,7 @@ class DelWarpCommand(
 
     override suspend fun execute(input: BungeecordCommandInput) {
         if (input.args.size != 1) {
-            input.sender.send().invalidCommandInput(this)
-            return
+            throw InvalidCommandArgumentsException()
         }
 
         val warpName = input.args.first()

--- a/src/main/kotlin/com/projectcitybuild/features/warps/commands/SetWarpCommand.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/warps/commands/SetWarpCommand.kt
@@ -1,10 +1,10 @@
 package com.projectcitybuild.features.warps.commands
 
+import com.projectcitybuild.core.InvalidCommandArgumentsException
 import com.projectcitybuild.platforms.spigot.environment.SpigotCommandInput
 import com.projectcitybuild.entities.SubChannel
 import com.projectcitybuild.modules.textcomponentbuilder.send
 import com.projectcitybuild.platforms.spigot.MessageToBungeecord
-import com.projectcitybuild.platforms.spigot.environment.CommandResult
 import com.projectcitybuild.platforms.spigot.environment.SpigotCommand
 import org.bukkit.entity.Player
 import org.bukkit.plugin.Plugin
@@ -13,17 +13,18 @@ class SetWarpCommand(
     private val plugin: Plugin
 ): SpigotCommand {
 
-    override val label: String = "setwarp"
+    override val label = "setwarp"
     override val permission = "pcbridge.warp.create"
+    override val usageHelp = "/setwarp <name>"
 
-    override suspend fun execute(input: SpigotCommandInput): CommandResult {
+    override suspend fun execute(input: SpigotCommandInput) {
         if (input.args.size != 1) {
-            return CommandResult.INVALID_INPUT
+            throw InvalidCommandArgumentsException()
         }
         val player = input.sender as? Player
         if (player == null) {
             input.sender.send().error("Console cannot use this command")
-            return CommandResult.EXECUTED
+            return
         }
 
         val warpName = input.args.first()
@@ -42,7 +43,5 @@ class SetWarpCommand(
                 player.location.yaw,
             )
         ).send()
-
-        return CommandResult.EXECUTED
     }
 }

--- a/src/main/kotlin/com/projectcitybuild/features/warps/commands/WarpCommand.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/warps/commands/WarpCommand.kt
@@ -1,5 +1,6 @@
 package com.projectcitybuild.features.warps.commands
 
+import com.projectcitybuild.core.InvalidCommandArgumentsException
 import com.projectcitybuild.entities.SubChannel
 import com.projectcitybuild.old_modules.storage.WarpFileStorage
 import com.projectcitybuild.platforms.bungeecord.MessageToSpigot
@@ -20,8 +21,7 @@ class WarpCommand(
 
     override suspend fun execute(input: BungeecordCommandInput) {
         if (input.args.size != 1) {
-            input.sender.send().invalidCommandInput(this)
-            return
+            throw InvalidCommandArgumentsException()
         }
         if (input.player == null) {
             input.sender.send().error("Console cannot use this command")

--- a/src/main/kotlin/com/projectcitybuild/features/warps/commands/WarpsCommand.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/warps/commands/WarpsCommand.kt
@@ -1,5 +1,6 @@
 package com.projectcitybuild.features.warps.commands
 
+import com.projectcitybuild.core.InvalidCommandArgumentsException
 import com.projectcitybuild.old_modules.storage.WarpFileStorage
 import com.projectcitybuild.platforms.bungeecord.environment.BungeecordCommand
 import com.projectcitybuild.platforms.bungeecord.environment.BungeecordCommandInput
@@ -19,8 +20,7 @@ class WarpsCommand(
 
     override suspend fun execute(input: BungeecordCommandInput) {
         if (input.args.size > 1) {
-            input.sender.send().invalidCommandInput(this)
-            return
+            throw InvalidCommandArgumentsException()
         }
 
         var page = input.args.firstOrNull()?.toInt() ?: 1
@@ -33,9 +33,11 @@ class WarpsCommand(
         }
         val warpList = availableWarps.chunked(warpsPerPage)[max(page - 1, 0)]
 
+        val pageDisplay = if (warpPages > 1) "${ChatColor.GRAY}(Page $page/$warpPages)" else ""
+
         input.sender.send().info(
             """
-            #${ChatColor.BOLD}Warps ${ChatColor.GRAY}(Page $page/$warpPages)${ChatColor.RESET}
+            #${ChatColor.BOLD}Warps $pageDisplay${ChatColor.RESET}
             #---
             #${warpList.joinToString(separator = ", ")}
             """.trimMargin("#"), isMultiLine = true

--- a/src/main/kotlin/com/projectcitybuild/features/warps/subchannels/AwaitJoinWarpChannelListener.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/warps/subchannels/AwaitJoinWarpChannelListener.kt
@@ -1,7 +1,8 @@
 package com.projectcitybuild.features.warps.subchannels
 
 import com.google.common.io.ByteArrayDataInput
-import com.projectcitybuild.modules.channels.SubChannelListener
+import com.projectcitybuild.entities.SubChannel
+import com.projectcitybuild.modules.channels.spigot.SpigotSubChannelListener
 import com.projectcitybuild.modules.logger.LoggerProvider
 import com.projectcitybuild.modules.sessioncache.SpigotSessionCache
 import org.bukkit.Location
@@ -13,9 +14,11 @@ class AwaitJoinWarpChannelListener(
     private val plugin: Plugin,
     private val logger: LoggerProvider,
     private val spigotSessionCache: SpigotSessionCache
-): SubChannelListener {
+): SpigotSubChannelListener {
 
-    override fun onSpigotMessageReceived(player: Player?, stream: ByteArrayDataInput) {
+    override val subChannel = SubChannel.WARP_AWAIT_JOIN
+
+    override fun onSpigotReceivedMessage(player: Player?, stream: ByteArrayDataInput) {
         val playerUUID = UUID.fromString(stream.readUTF())
         val worldName = stream.readUTF()
         val x = stream.readDouble()

--- a/src/main/kotlin/com/projectcitybuild/features/warps/subchannels/ImmediateWarpChannelListener.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/warps/subchannels/ImmediateWarpChannelListener.kt
@@ -1,7 +1,8 @@
 package com.projectcitybuild.features.warps.subchannels
 
 import com.google.common.io.ByteArrayDataInput
-import com.projectcitybuild.modules.channels.SubChannelListener
+import com.projectcitybuild.entities.SubChannel
+import com.projectcitybuild.modules.channels.spigot.SpigotSubChannelListener
 import com.projectcitybuild.modules.logger.LoggerProvider
 import org.bukkit.Location
 import org.bukkit.entity.Player
@@ -12,9 +13,11 @@ import java.util.*
 class ImmediateWarpChannelListener(
     private val plugin: Plugin,
     private val logger: LoggerProvider
-): SubChannelListener {
+): SpigotSubChannelListener {
 
-    override fun onSpigotMessageReceived(player: Player?, stream: ByteArrayDataInput) {
+    override val subChannel = SubChannel.WARP_IMMEDIATELY
+
+    override fun onSpigotReceivedMessage(player: Player?, stream: ByteArrayDataInput) {
         val playerUUID = UUID.fromString(stream.readUTF())
         val worldName = stream.readUTF()
         val x = stream.readDouble()

--- a/src/main/kotlin/com/projectcitybuild/features/warps/subchannels/IncomingSetWarpListener.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/warps/subchannels/IncomingSetWarpListener.kt
@@ -1,9 +1,9 @@
-package com.projectcitybuild.features.warps.listeners
+package com.projectcitybuild.features.warps.subchannels
 
-import com.google.common.io.ByteStreams
-import com.projectcitybuild.entities.Channel
+import com.google.common.io.ByteArrayDataInput
 import com.projectcitybuild.entities.SubChannel
 import com.projectcitybuild.entities.Warp
+import com.projectcitybuild.modules.channels.bungeecord.BungeecordSubChannelListener
 import com.projectcitybuild.old_modules.storage.SerializableDate
 import com.projectcitybuild.old_modules.storage.SerializableUUID
 import com.projectcitybuild.old_modules.storage.WarpFileStorage
@@ -11,31 +11,21 @@ import com.projectcitybuild.modules.textcomponentbuilder.send
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import net.md_5.bungee.api.connection.Connection
 import net.md_5.bungee.api.connection.ProxiedPlayer
-import net.md_5.bungee.api.event.PluginMessageEvent
-import net.md_5.bungee.api.plugin.Listener
-import net.md_5.bungee.event.EventHandler
 import java.util.*
 
 class IncomingSetWarpListener(
     private val warpStorage: WarpFileStorage
-): Listener {
+): BungeecordSubChannelListener {
 
-    @EventHandler
-    fun onPluginMessageReceived(event: PluginMessageEvent) {
-        if (event.tag != Channel.BUNGEECORD) return
+    override val subChannel = SubChannel.SET_WARP
 
-        val stream = ByteStreams.newDataInput(event.data)
-        val subChannel = stream.readUTF()
-
-        if (subChannel != SubChannel.SET_WARP)
+    override fun onBungeecordReceivedMessage(receiver: Connection, sender: Connection, stream: ByteArrayDataInput) {
+        if (receiver !is ProxiedPlayer)
             return
 
-        if (event.receiver !is ProxiedPlayer)
-            return
-
-        val player = event.receiver as ProxiedPlayer
-        val serverName = player.server.info.name
+        val serverName = receiver.server.info.name
 
         val warpName = stream.readUTF()
         val worldName = stream.readUTF()
@@ -46,14 +36,14 @@ class IncomingSetWarpListener(
         val yaw = stream.readFloat()
 
         if (warpStorage.exists(warpName)) {
-            player.send().error("A warp for $warpName already exists")
+            receiver.send().error("A warp for $warpName already exists")
             return
         }
 
         val warp = Warp(
             serverName,
             worldName,
-            SerializableUUID(player.uniqueId),
+            SerializableUUID(receiver.uniqueId),
             x,
             y,
             z,
@@ -63,7 +53,7 @@ class IncomingSetWarpListener(
         )
         CoroutineScope(Dispatchers.IO).launch {
             warpStorage.save(warpName, warp)
-            player.send().success("Created warp for $warpName")
+            receiver.send().success("Created warp for $warpName")
         }
     }
 }

--- a/src/main/kotlin/com/projectcitybuild/modules/channels/SubChannelListener.kt
+++ b/src/main/kotlin/com/projectcitybuild/modules/channels/SubChannelListener.kt
@@ -1,9 +1,0 @@
-package com.projectcitybuild.modules.channels
-
-import com.google.common.io.ByteArrayDataInput
-import org.bukkit.entity.Player
-
-interface SubChannelListener {
-
-    fun onSpigotMessageReceived(player: Player?, stream: ByteArrayDataInput)
-}

--- a/src/main/kotlin/com/projectcitybuild/modules/channels/bungeecord/BungeecordMessageListener.kt
+++ b/src/main/kotlin/com/projectcitybuild/modules/channels/bungeecord/BungeecordMessageListener.kt
@@ -1,0 +1,35 @@
+package com.projectcitybuild.modules.channels.bungeecord
+
+import com.google.common.io.ByteStreams
+import com.projectcitybuild.core.BungeecordListener
+import com.projectcitybuild.entities.Channel
+import com.projectcitybuild.modules.logger.LoggerProvider
+import net.md_5.bungee.api.event.PluginMessageEvent
+import net.md_5.bungee.event.EventHandler
+
+class BungeecordMessageListener(
+    private val logger: LoggerProvider
+): BungeecordListener {
+
+    private val listeners = HashMap<String, BungeecordSubChannelListener>()
+
+    fun register(listener: BungeecordSubChannelListener) {
+        listeners[listener.subChannel] = listener
+    }
+
+    @EventHandler
+    fun onPluginMessageReceived(event: PluginMessageEvent) {
+        if (event.tag != Channel.BUNGEECORD) return
+
+        val stream = ByteStreams.newDataInput(event.data)
+        val subChannel = stream.readUTF()
+
+        val listener = listeners[subChannel]
+        if (listener == null) {
+            logger.warning("No listener for $subChannel subchannel. Message will be discarded")
+            return
+        }
+
+        listener.onBungeecordReceivedMessage(event.receiver, event.sender, stream)
+    }
+}

--- a/src/main/kotlin/com/projectcitybuild/modules/channels/bungeecord/BungeecordSubChannelListener.kt
+++ b/src/main/kotlin/com/projectcitybuild/modules/channels/bungeecord/BungeecordSubChannelListener.kt
@@ -1,0 +1,11 @@
+package com.projectcitybuild.modules.channels.bungeecord
+
+import com.google.common.io.ByteArrayDataInput
+import net.md_5.bungee.api.connection.Connection
+
+interface BungeecordSubChannelListener {
+
+    val subChannel: String
+
+    fun onBungeecordReceivedMessage(receiver: Connection, sender: Connection, stream: ByteArrayDataInput)
+}

--- a/src/main/kotlin/com/projectcitybuild/modules/channels/spigot/SpigotMessageListener.kt
+++ b/src/main/kotlin/com/projectcitybuild/modules/channels/spigot/SpigotMessageListener.kt
@@ -1,4 +1,4 @@
-package com.projectcitybuild.modules.channels
+package com.projectcitybuild.modules.channels.spigot
 
 import com.google.common.io.ByteStreams
 import com.projectcitybuild.entities.Channel
@@ -10,10 +10,10 @@ class SpigotMessageListener(
     private val logger: LoggerProvider
 ): PluginMessageListener {
 
-    private val listeners = HashMap<String, SubChannelListener>()
+    private val listeners = HashMap<String, SpigotSubChannelListener>()
 
-    fun register(subChannel: String, listener: SubChannelListener) {
-        listeners[subChannel] = listener
+    fun register(listener: SpigotSubChannelListener) {
+        listeners[listener.subChannel] = listener
     }
 
     override fun onPluginMessageReceived(channel: String?, player: Player?, message: ByteArray?) {
@@ -28,6 +28,6 @@ class SpigotMessageListener(
             return
         }
 
-        listener.onSpigotMessageReceived(player, stream)
+        listener.onSpigotReceivedMessage(player, stream)
     }
 }

--- a/src/main/kotlin/com/projectcitybuild/modules/channels/spigot/SpigotSubChannelListener.kt
+++ b/src/main/kotlin/com/projectcitybuild/modules/channels/spigot/SpigotSubChannelListener.kt
@@ -1,0 +1,10 @@
+package com.projectcitybuild.modules.channels.spigot
+
+import com.google.common.io.ByteArrayDataInput
+import org.bukkit.entity.Player
+
+interface SpigotSubChannelListener {
+
+    val subChannel: String
+    fun onSpigotReceivedMessage(player: Player?, stream: ByteArrayDataInput)
+}

--- a/src/main/kotlin/com/projectcitybuild/modules/textcomponentbuilder/MessageSender.kt
+++ b/src/main/kotlin/com/projectcitybuild/modules/textcomponentbuilder/MessageSender.kt
@@ -55,13 +55,4 @@ class MessageSender(
             }
         )
     }
-
-    fun invalidCommandInput(command: BungeecordCommand) {
-        receiver.sendMessage(
-            TextComponent(command.usageHelp).also {
-                it.color = ChatColor.GRAY
-                it.isItalic = true
-            }
-        )
-    }
 }

--- a/src/main/kotlin/com/projectcitybuild/modules/textcomponentbuilder/MessageSender.kt
+++ b/src/main/kotlin/com/projectcitybuild/modules/textcomponentbuilder/MessageSender.kt
@@ -1,6 +1,5 @@
 package com.projectcitybuild.modules.textcomponentbuilder
 
-import com.projectcitybuild.platforms.bungeecord.environment.BungeecordCommand
 import com.projectcitybuild.platforms.bungeecord.extensions.add
 import net.md_5.bungee.api.ChatColor
 import net.md_5.bungee.api.chat.TextComponent

--- a/src/main/kotlin/com/projectcitybuild/platforms/bungeecord/environment/BungeecordCommandRegistry.kt
+++ b/src/main/kotlin/com/projectcitybuild/platforms/bungeecord/environment/BungeecordCommandRegistry.kt
@@ -1,11 +1,14 @@
 package com.projectcitybuild.platforms.bungeecord.environment
 
+import com.projectcitybuild.core.InvalidCommandArgumentsException
 import com.projectcitybuild.modules.logger.LoggerProvider
 import com.projectcitybuild.modules.textcomponentbuilder.send
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import net.md_5.bungee.api.ChatColor
 import net.md_5.bungee.api.CommandSender
+import net.md_5.bungee.api.chat.TextComponent
 import net.md_5.bungee.api.plugin.Command
 import net.md_5.bungee.api.plugin.Plugin
 import net.md_5.bungee.api.plugin.TabExecutor
@@ -56,9 +59,18 @@ class BungeecordCommandRegistry constructor(
                             command.execute(input)
                         }
                     }.onFailure { throwable ->
-                        sender.send().error(throwable.message ?: "An internal error occurred performing your command")
-                        throwable.message?.let { logger.fatal(it) }
-                        throwable.printStackTrace()
+                        if (throwable is InvalidCommandArgumentsException) {
+                            sender.sendMessage(
+                                TextComponent(command.usageHelp).also {
+                                    it.color = ChatColor.GRAY
+                                    it.isItalic = true
+                                }
+                            )
+                        } else {
+                            sender.send().error(throwable.message ?: "An internal error occurred performing your command")
+                            throwable.message?.let { logger.fatal(it) }
+                            throwable.printStackTrace()
+                        }
                     }
                     true
                 },

--- a/src/main/kotlin/com/projectcitybuild/platforms/spigot/SpigotPlatform.kt
+++ b/src/main/kotlin/com/projectcitybuild/platforms/spigot/SpigotPlatform.kt
@@ -14,7 +14,7 @@ import com.projectcitybuild.platforms.spigot.environment.*
 import com.projectcitybuild.features.chat.ChatModule
 import com.projectcitybuild.features.joinmessage.JoinMessageModule
 import com.projectcitybuild.features.teleporting.TeleportModule
-import com.projectcitybuild.modules.channels.SpigotMessageListener
+import com.projectcitybuild.modules.channels.spigot.SpigotMessageListener
 import com.projectcitybuild.modules.config.implementations.SpigotConfig
 import com.projectcitybuild.modules.logger.implementations.SpigotLogger
 import com.projectcitybuild.modules.permissions.PermissionsManager
@@ -77,7 +77,7 @@ class SpigotPlatform: JavaPlugin() {
         .forEach { module ->
             module.spigotCommands.forEach { commandRegistry?.register(it) }
             module.spigotListeners.forEach { listenerRegistry?.register(it) }
-            module.spigotSubChannelListeners.forEach { pluginMessageListener.register(it.key, it.value) }
+            module.spigotSubChannelListeners.forEach { pluginMessageListener.register(it) }
         }
 
         listenerRegistry?.register(

--- a/src/main/kotlin/com/projectcitybuild/platforms/spigot/environment/SpigotCommand.kt
+++ b/src/main/kotlin/com/projectcitybuild/platforms/spigot/environment/SpigotCommand.kt
@@ -19,10 +19,8 @@ interface SpigotCommand {
     // Permission node required to execute the command
     val permission: String
 
-    suspend fun execute(input: SpigotCommandInput): CommandResult
-}
+    // Message shown to the user if the command input was invalid
+    val usageHelp: String
 
-enum class CommandResult {
-    INVALID_INPUT,
-    EXECUTED,
+    suspend fun execute(input: SpigotCommandInput)
 }


### PR DESCRIPTION
* Unifies the Spigot and Bungeecord command interface - no more `CommandResult` return
* Adds typealias to better differentiate between a Spigot and Bungeecord event listener
* Reduces boilerplate code for Bungeecord subchannel listeners