### PR TITLE
Guess player and warp names

### DIFF
--- a/src/main/kotlin/com/projectcitybuild/features/chat/ChatModule.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/chat/ChatModule.kt
@@ -6,6 +6,7 @@ import com.projectcitybuild.features.chat.commands.*
 import com.projectcitybuild.features.chat.listeners.ChatListener
 import com.projectcitybuild.features.chat.subchannels.IncomingChatChannelListener
 import com.projectcitybuild.modules.channels.bungeecord.BungeecordSubChannelListener
+import com.projectcitybuild.modules.nameguesser.NameGuesser
 import com.projectcitybuild.platforms.bungeecord.environment.BungeecordCommand
 import com.projectcitybuild.old_modules.playerconfig.PlayerConfigRepository
 import com.projectcitybuild.modules.playeruuid.PlayerUUIDRepository
@@ -21,7 +22,8 @@ class ChatModule {
         playerUUIDRepository: PlayerUUIDRepository,
         playerConfigRepository: PlayerConfigRepository,
         chatGroupFormatBuilder: ChatGroupFormatBuilder,
-        sessionCache: BungeecordSessionCache
+        sessionCache: BungeecordSessionCache,
+        nameGuesser: NameGuesser
     ): BungeecordFeatureModule {
 
         override val bungeecordCommands: Array<BungeecordCommand> = arrayOf(
@@ -31,7 +33,7 @@ class ChatModule {
             ReplyCommand(proxyServer, playerConfigRepository, sessionCache),
             UnignoreCommand(proxyServer, playerUUIDRepository, playerConfigRepository),
             UnmuteCommand(proxyServer, playerConfigRepository),
-            WhisperCommand(proxyServer, playerConfigRepository, sessionCache),
+            WhisperCommand(proxyServer, playerConfigRepository, sessionCache, nameGuesser),
         )
 
         override val bungeecordSubChannelListeners: Array<BungeecordSubChannelListener> = arrayOf(

--- a/src/main/kotlin/com/projectcitybuild/features/chat/commands/WhisperCommand.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/chat/commands/WhisperCommand.kt
@@ -2,6 +2,7 @@ package com.projectcitybuild.features.chat.commands
 
 import com.projectcitybuild.core.InvalidCommandArgumentsException
 import com.projectcitybuild.core.extensions.joinWithWhitespaces
+import com.projectcitybuild.modules.nameguesser.NameGuesser
 import com.projectcitybuild.modules.sessioncache.BungeecordSessionCache
 import com.projectcitybuild.old_modules.playerconfig.PlayerConfigRepository
 import com.projectcitybuild.platforms.bungeecord.environment.BungeecordCommand
@@ -15,7 +16,8 @@ import net.md_5.bungee.api.chat.TextComponent
 class WhisperCommand(
     private val proxyServer: ProxyServer,
     private val playerConfigRepository: PlayerConfigRepository,
-    private val sessionCache: BungeecordSessionCache
+    private val sessionCache: BungeecordSessionCache,
+    private val nameGuesser: NameGuesser
 ): BungeecordCommand {
 
     override val label = "whisper"
@@ -29,8 +31,7 @@ class WhisperCommand(
         }
         val targetPlayerName = input.args.first()
 
-        val targetPlayer = proxyServer.players
-            .firstOrNull { it.name.lowercase() == targetPlayerName.lowercase() }
+        val targetPlayer = nameGuesser.guessClosest(targetPlayerName, proxyServer.players) { it.name }
 
         if (targetPlayer == null) {
             input.sender.send().error("Player not found")

--- a/src/main/kotlin/com/projectcitybuild/features/ranksync/RankSyncModule.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/ranksync/RankSyncModule.kt
@@ -7,6 +7,7 @@ import com.projectcitybuild.platforms.bungeecord.environment.BungeecordCommand
 import com.projectcitybuild.features.ranksync.commands.SyncCommand
 import com.projectcitybuild.features.ranksync.commands.SyncOtherCommand
 import com.projectcitybuild.features.ranksync.listeners.SyncRankLoginListener
+import com.projectcitybuild.modules.nameguesser.NameGuesser
 import net.md_5.bungee.api.ProxyServer
 import net.md_5.bungee.api.plugin.Listener
 
@@ -14,12 +15,13 @@ class RankSyncModule(
     proxyServer: ProxyServer,
     apiRequestFactory: APIRequestFactory,
     apiClient: APIClient,
-    syncPlayerGroupService: SyncPlayerGroupService
+    syncPlayerGroupService: SyncPlayerGroupService,
+    nameGuesser: NameGuesser
 ): BungeecordFeatureModule {
 
     override val bungeecordCommands: Array<BungeecordCommand> = arrayOf(
         SyncCommand(apiRequestFactory, apiClient, syncPlayerGroupService),
-        SyncOtherCommand(proxyServer, syncPlayerGroupService),
+        SyncOtherCommand(proxyServer, syncPlayerGroupService, nameGuesser),
     )
 
     override val bungeecordListeners: Array<Listener> = arrayOf(

--- a/src/main/kotlin/com/projectcitybuild/features/teleporting/TeleportModule.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/teleporting/TeleportModule.kt
@@ -11,6 +11,7 @@ import com.projectcitybuild.features.teleporting.subchannels.AwaitJoinTeleportCh
 import com.projectcitybuild.features.teleporting.subchannels.ImmediateTeleportChannelListener
 import com.projectcitybuild.modules.channels.spigot.SpigotSubChannelListener
 import com.projectcitybuild.modules.logger.LoggerProvider
+import com.projectcitybuild.modules.nameguesser.NameGuesser
 import com.projectcitybuild.modules.sessioncache.SpigotSessionCache
 import com.projectcitybuild.old_modules.playerconfig.PlayerConfigRepository
 import net.md_5.bungee.api.ProxyServer
@@ -20,13 +21,14 @@ class TeleportModule {
 
     class Bungeecord(
         proxyServer: ProxyServer,
-        playerConfigRepository: PlayerConfigRepository
+        playerConfigRepository: PlayerConfigRepository,
+        nameGuesser: NameGuesser
     ): BungeecordFeatureModule {
         override val bungeecordCommands: Array<BungeecordCommand> = arrayOf(
-            TPCommand(proxyServer, playerConfigRepository),
-            TPHereCommand(proxyServer),
-            TPOCommand(proxyServer),
-            TPToggleCommand(proxyServer, playerConfigRepository),
+            TPCommand(proxyServer, playerConfigRepository, nameGuesser),
+            TPHereCommand(proxyServer, nameGuesser),
+            TPOCommand(proxyServer, nameGuesser),
+//            TPToggleCommand(proxyServer, playerConfigRepository),
         )
     }
 

--- a/src/main/kotlin/com/projectcitybuild/features/teleporting/commands/TPCommand.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/teleporting/commands/TPCommand.kt
@@ -2,6 +2,7 @@ package com.projectcitybuild.features.teleporting.commands
 
 import com.projectcitybuild.core.InvalidCommandArgumentsException
 import com.projectcitybuild.entities.SubChannel
+import com.projectcitybuild.modules.nameguesser.NameGuesser
 import com.projectcitybuild.old_modules.playerconfig.PlayerConfigRepository
 import com.projectcitybuild.platforms.bungeecord.MessageToSpigot
 import com.projectcitybuild.platforms.bungeecord.environment.BungeecordCommand
@@ -12,7 +13,8 @@ import net.md_5.bungee.api.ProxyServer
 
 class TPCommand(
     private val proxyServer: ProxyServer,
-    private val playerConfigRepository: PlayerConfigRepository
+    private val playerConfigRepository: PlayerConfigRepository,
+    private val nameGuesser: NameGuesser
 ): BungeecordCommand {
 
     override val label: String = "tp"
@@ -29,7 +31,7 @@ class TPCommand(
         }
 
         val targetPlayerName = input.args.first()
-        val targetPlayer = proxyServer.players.firstOrNull { it.name.lowercase() == targetPlayerName.lowercase() }
+        val targetPlayer = nameGuesser.guessClosest(targetPlayerName, proxyServer.players) { it.name }
         if (targetPlayer == null) {
             input.sender.send().error("Player $targetPlayerName not found")
             return

--- a/src/main/kotlin/com/projectcitybuild/features/teleporting/commands/TPHereCommand.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/teleporting/commands/TPHereCommand.kt
@@ -2,6 +2,7 @@ package com.projectcitybuild.features.teleporting.commands
 
 import com.projectcitybuild.core.InvalidCommandArgumentsException
 import com.projectcitybuild.entities.SubChannel
+import com.projectcitybuild.modules.nameguesser.NameGuesser
 import com.projectcitybuild.platforms.bungeecord.MessageToSpigot
 import com.projectcitybuild.platforms.bungeecord.environment.BungeecordCommand
 import com.projectcitybuild.platforms.bungeecord.environment.BungeecordCommandInput
@@ -11,6 +12,7 @@ import net.md_5.bungee.api.ProxyServer
 
 class TPHereCommand(
     private val proxyServer: ProxyServer,
+    private val nameGuesser: NameGuesser
 ): BungeecordCommand {
 
     override val label: String = "tphere"
@@ -27,7 +29,7 @@ class TPHereCommand(
         }
 
         val targetPlayerName = input.args.first()
-        val targetPlayer = proxyServer.players.firstOrNull { it.name.lowercase() == targetPlayerName.lowercase() }
+        val targetPlayer = nameGuesser.guessClosest(targetPlayerName, proxyServer.players) { it.name }
         if (targetPlayer == null) {
             input.sender.send().error("Player $targetPlayerName not found")
             return

--- a/src/main/kotlin/com/projectcitybuild/features/teleporting/commands/TPOCommand.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/teleporting/commands/TPOCommand.kt
@@ -2,6 +2,7 @@ package com.projectcitybuild.features.teleporting.commands
 
 import com.projectcitybuild.core.InvalidCommandArgumentsException
 import com.projectcitybuild.entities.SubChannel
+import com.projectcitybuild.modules.nameguesser.NameGuesser
 import com.projectcitybuild.platforms.bungeecord.MessageToSpigot
 import com.projectcitybuild.platforms.bungeecord.environment.BungeecordCommand
 import com.projectcitybuild.platforms.bungeecord.environment.BungeecordCommandInput
@@ -10,7 +11,8 @@ import net.md_5.bungee.api.CommandSender
 import net.md_5.bungee.api.ProxyServer
 
 class TPOCommand(
-    private val proxyServer: ProxyServer
+    private val proxyServer: ProxyServer,
+    private val nameGuesser: NameGuesser
 ): BungeecordCommand {
 
     override val label: String = "tpo"
@@ -27,7 +29,7 @@ class TPOCommand(
         }
 
         val targetPlayerName = input.args.first()
-        val targetPlayer = proxyServer.players.firstOrNull { it.name.lowercase() == targetPlayerName.lowercase() }
+        val targetPlayer = nameGuesser.guessClosest(targetPlayerName, proxyServer.players) { it.name }
         if (targetPlayer == null) {
             input.sender.send().error("Player $targetPlayerName not found")
             return

--- a/src/main/kotlin/com/projectcitybuild/features/warps/WarpModule.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/warps/WarpModule.kt
@@ -14,6 +14,7 @@ import com.projectcitybuild.features.warps.subchannels.ImmediateWarpChannelListe
 import com.projectcitybuild.modules.channels.bungeecord.BungeecordSubChannelListener
 import com.projectcitybuild.modules.channels.spigot.SpigotSubChannelListener
 import com.projectcitybuild.modules.logger.LoggerProvider
+import com.projectcitybuild.modules.nameguesser.NameGuesser
 import com.projectcitybuild.modules.sessioncache.SpigotSessionCache
 import com.projectcitybuild.old_modules.storage.WarpFileStorage
 import com.projectcitybuild.platforms.spigot.environment.SpigotCommand
@@ -24,11 +25,12 @@ class WarpModule {
 
     class Bungeecord(
         proxyServer: ProxyServer,
-        warpFileStorage: WarpFileStorage
+        warpFileStorage: WarpFileStorage,
+        nameGuesser: NameGuesser
     ): BungeecordFeatureModule {
         override val bungeecordCommands: Array<BungeecordCommand> = arrayOf(
             DelWarpCommand(warpFileStorage),
-            WarpCommand(proxyServer, warpFileStorage),
+            WarpCommand(proxyServer, warpFileStorage, nameGuesser),
             WarpsCommand(warpFileStorage),
         )
 

--- a/src/main/kotlin/com/projectcitybuild/features/warps/commands/WarpCommand.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/warps/commands/WarpCommand.kt
@@ -2,6 +2,7 @@ package com.projectcitybuild.features.warps.commands
 
 import com.projectcitybuild.core.InvalidCommandArgumentsException
 import com.projectcitybuild.entities.SubChannel
+import com.projectcitybuild.modules.nameguesser.NameGuesser
 import com.projectcitybuild.old_modules.storage.WarpFileStorage
 import com.projectcitybuild.platforms.bungeecord.MessageToSpigot
 import com.projectcitybuild.platforms.bungeecord.environment.BungeecordCommand
@@ -12,7 +13,8 @@ import net.md_5.bungee.api.ProxyServer
 
 class WarpCommand(
     private val proxyServer: ProxyServer,
-    private val warpFileStorage: WarpFileStorage
+    private val warpFileStorage: WarpFileStorage,
+    private val nameGuesser: NameGuesser
 ): BungeecordCommand {
 
     override val label: String = "warp"
@@ -28,12 +30,16 @@ class WarpCommand(
             return
         }
 
-        val warpName = input.args.first()
-        val warp = warpFileStorage.load(warpName)
-        if (warp == null) {
+        val availableWarpNames = warpFileStorage.keys()
+
+        val targetWarpName = input.args.first()
+        val warpName = nameGuesser.guessClosest(targetWarpName, availableWarpNames)
+        if (warpName == null) {
             input.sender.send().error("Warp $warpName does not exist")
             return
         }
+
+        val warp = warpFileStorage.load(warpName)!!
 
         val targetServer = proxyServer.servers[warp.serverName]
         if (targetServer == null) {

--- a/src/main/kotlin/com/projectcitybuild/modules/nameguesser/NameGuesser.kt
+++ b/src/main/kotlin/com/projectcitybuild/modules/nameguesser/NameGuesser.kt
@@ -1,0 +1,33 @@
+package com.projectcitybuild.modules.nameguesser
+
+import net.md_5.bungee.api.ProxyServer
+
+class NameGuesser {
+    fun guessClosest(string: String, collection: Collection<String>): String? {
+        return guessClosest(string, collection) { it }
+    }
+
+    fun <T> guessClosest(string: String, collection: Collection<T>, comparison: (T) -> String): T? {
+        val searchString = string.lowercase()
+
+        var partialMatches: MutableList<String> = mutableListOf()
+
+        collection.forEach { element ->
+            val elementString = comparison(element).lowercase()
+            if (elementString == searchString) {
+                return element
+            }
+            if (elementString.startsWith(searchString)) {
+                partialMatches.add(elementString)
+            }
+        }
+
+        val closestMatchingString = partialMatches
+            .sortedDescending()
+            .firstOrNull()
+            ?: return null
+
+        return collection
+            .first { comparison(it).lowercase() == closestMatchingString }
+    }
+}

--- a/src/main/kotlin/com/projectcitybuild/platforms/bungeecord/BungeecordPlatform.kt
+++ b/src/main/kotlin/com/projectcitybuild/platforms/bungeecord/BungeecordPlatform.kt
@@ -25,6 +25,7 @@ import com.projectcitybuild.features.ranksync.SyncPlayerGroupService
 import com.projectcitybuild.modules.channels.bungeecord.BungeecordMessageListener
 import com.projectcitybuild.modules.config.implementations.BungeecordConfig
 import com.projectcitybuild.modules.logger.implementations.BungeecordLogger
+import com.projectcitybuild.modules.nameguesser.NameGuesser
 import com.projectcitybuild.modules.sessioncache.BungeecordSessionCache
 import com.projectcitybuild.platforms.bungeecord.environment.BungeecordTimer
 import com.projectcitybuild.old_modules.storage.HubFileStorage
@@ -134,13 +135,44 @@ class BungeecordPlatform: Plugin() {
         listenerRegistry?.register(subChannelListener)
 
         arrayOf(
-            BanModule(proxy, playerUUIDRepository, banRepository, bungeecordLogger),
-            ChatModule.Bungeecord(proxy, playerUUIDRepository, playerConfigRepository, chatGroupFormatBuilder, sessionCache!!),
-            HubModule.Bungeecord(proxy, hubFileStorage),
-            JoinMessageModule.Bungee(proxy),
-            RankSyncModule(proxy, apiRequestFactory, apiClient, syncPlayerGroupService),
-            TeleportModule.Bungeecord(proxy, playerConfigRepository),
-            WarpModule.Bungeecord(proxy, warpFileStorage),
+            BanModule(
+                proxy,
+                playerUUIDRepository,
+                banRepository,
+                bungeecordLogger
+            ),
+            ChatModule.Bungeecord(
+                proxy,
+                playerUUIDRepository,
+                playerConfigRepository,
+                chatGroupFormatBuilder,
+                sessionCache!!,
+                NameGuesser()
+            ),
+            HubModule.Bungeecord(
+                proxy,
+                hubFileStorage
+            ),
+            JoinMessageModule.Bungee(
+                proxy
+            ),
+            RankSyncModule(
+                proxy,
+                apiRequestFactory,
+                apiClient,
+                syncPlayerGroupService,
+                NameGuesser()
+            ),
+            TeleportModule.Bungeecord(
+                proxy,
+                playerConfigRepository,
+                NameGuesser()
+            ),
+            WarpModule.Bungeecord(
+                proxy,
+                warpFileStorage,
+                NameGuesser()
+            ),
         ).forEach { module ->
             module.bungeecordCommands.forEach { commandRegistry?.register(it) }
             module.bungeecordListeners.forEach { listenerRegistry?.register(it) }


### PR DESCRIPTION
Fixes #51 

Allows you to type in `/warp t` and have it auto-guess it as `/warp test`. And same for various `/tp` and messaging commands.
Only applies to commands which do not work on offline players