### PR TITLE
Sort warp list and make warps clickable

### DIFF
--- a/src/main/kotlin/com/projectcitybuild/entities/PluginConfig.kt
+++ b/src/main/kotlin/com/projectcitybuild/entities/PluginConfig.kt
@@ -13,6 +13,8 @@ sealed class PluginConfig {
         val API_BASE_URL = "api.base_url" defaultTo "https://projectcitybuild.com/api/"
         val API_IS_LOGGING_ENABLED = "api.is_logging_enabled" defaultTo false
 
+        val WARPS_PER_PAGE = "warps.warps_per_page" defaultTo 15
+
         val GROUPS_GUEST = "groups.guest" defaultTo "guest"
         val GROUPS_BUILD_PRIORITY = "groups.build_priority" defaultTo arrayListOf(
             "architect",

--- a/src/main/kotlin/com/projectcitybuild/features/chat/commands/ACommand.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/chat/commands/ACommand.kt
@@ -4,7 +4,6 @@ import com.projectcitybuild.core.InvalidCommandArgumentsException
 import com.projectcitybuild.platforms.bungeecord.environment.BungeecordCommand
 import com.projectcitybuild.platforms.bungeecord.environment.BungeecordCommandInput
 import com.projectcitybuild.platforms.bungeecord.extensions.add
-import com.projectcitybuild.modules.textcomponentbuilder.send
 import net.md_5.bungee.api.ChatColor
 import net.md_5.bungee.api.CommandSender
 import net.md_5.bungee.api.ProxyServer

--- a/src/main/kotlin/com/projectcitybuild/features/warps/WarpModule.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/warps/WarpModule.kt
@@ -13,6 +13,7 @@ import com.projectcitybuild.features.warps.subchannels.AwaitJoinWarpChannelListe
 import com.projectcitybuild.features.warps.subchannels.ImmediateWarpChannelListener
 import com.projectcitybuild.modules.channels.bungeecord.BungeecordSubChannelListener
 import com.projectcitybuild.modules.channels.spigot.SpigotSubChannelListener
+import com.projectcitybuild.modules.config.ConfigProvider
 import com.projectcitybuild.modules.logger.LoggerProvider
 import com.projectcitybuild.modules.nameguesser.NameGuesser
 import com.projectcitybuild.modules.sessioncache.SpigotSessionCache
@@ -26,12 +27,13 @@ class WarpModule {
     class Bungeecord(
         proxyServer: ProxyServer,
         warpFileStorage: WarpFileStorage,
-        nameGuesser: NameGuesser
+        nameGuesser: NameGuesser,
+        config: ConfigProvider
     ): BungeecordFeatureModule {
         override val bungeecordCommands: Array<BungeecordCommand> = arrayOf(
             DelWarpCommand(warpFileStorage),
             WarpCommand(proxyServer, warpFileStorage, nameGuesser),
-            WarpsCommand(warpFileStorage),
+            WarpsCommand(warpFileStorage, config),
         )
 
         override val bungeecordSubChannelListeners: Array<BungeecordSubChannelListener> = arrayOf(

--- a/src/main/kotlin/com/projectcitybuild/features/warps/commands/WarpsCommand.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/warps/commands/WarpsCommand.kt
@@ -9,6 +9,7 @@ import net.md_5.bungee.api.ChatColor
 import net.md_5.bungee.api.CommandSender
 import kotlin.math.ceil
 import kotlin.math.max
+import kotlin.math.min
 
 class WarpsCommand(
     private val warpFileStorage: WarpFileStorage
@@ -28,10 +29,11 @@ class WarpsCommand(
         val availableWarps = warpFileStorage.keys()
         val warpPages = ceil((availableWarps.size / warpsPerPage).toDouble()).toInt()
 
-        if (page > warpPages) {
-            page = warpPages
-        }
-        val warpList = availableWarps.chunked(warpsPerPage)[max(page - 1, 0)]
+        page = min(page, warpPages)
+
+        val warpList = availableWarps
+            .sortedDescending()
+            .chunked(warpsPerPage)[max(page - 1, 0)]
 
         val pageDisplay = if (warpPages > 1) "${ChatColor.GRAY}(Page $page/$warpPages)" else ""
 

--- a/src/main/kotlin/com/projectcitybuild/features/warps/commands/WarpsCommand.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/warps/commands/WarpsCommand.kt
@@ -39,7 +39,7 @@ class WarpsCommand(
         page = min(page, totalWarpPages)
 
         val warpList = availableWarps
-            .sortedDescending()
+            .sorted()
             .chunked(warpsPerPage)[max(page - 1, 0)]
 
         val clickableWarps = warpList.map { name ->

--- a/src/main/kotlin/com/projectcitybuild/features/warps/commands/WarpsCommand.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/warps/commands/WarpsCommand.kt
@@ -1,18 +1,25 @@
 package com.projectcitybuild.features.warps.commands
 
 import com.projectcitybuild.core.InvalidCommandArgumentsException
+import com.projectcitybuild.entities.PluginConfig
+import com.projectcitybuild.modules.config.ConfigProvider
 import com.projectcitybuild.old_modules.storage.WarpFileStorage
 import com.projectcitybuild.platforms.bungeecord.environment.BungeecordCommand
 import com.projectcitybuild.platforms.bungeecord.environment.BungeecordCommandInput
 import com.projectcitybuild.modules.textcomponentbuilder.send
+import com.projectcitybuild.platforms.bungeecord.extensions.add
+import com.projectcitybuild.platforms.bungeecord.extensions.addIf
 import net.md_5.bungee.api.ChatColor
 import net.md_5.bungee.api.CommandSender
+import net.md_5.bungee.api.chat.ClickEvent
+import net.md_5.bungee.api.chat.TextComponent
 import kotlin.math.ceil
 import kotlin.math.max
 import kotlin.math.min
 
 class WarpsCommand(
-    private val warpFileStorage: WarpFileStorage
+    private val warpFileStorage: WarpFileStorage,
+    private val config: ConfigProvider
 ): BungeecordCommand {
 
     override val label: String = "warps"
@@ -25,25 +32,38 @@ class WarpsCommand(
         }
 
         var page = input.args.firstOrNull()?.toInt() ?: 1
-        val warpsPerPage = 15
+        val warpsPerPage = config.get(PluginConfig.WARPS_PER_PAGE)
         val availableWarps = warpFileStorage.keys()
-        val warpPages = ceil((availableWarps.size / warpsPerPage).toDouble()).toInt()
+        val totalWarpPages = ceil((availableWarps.size / warpsPerPage).toDouble()).toInt()
 
-        page = min(page, warpPages)
+        page = min(page, totalWarpPages)
 
         val warpList = availableWarps
             .sortedDescending()
             .chunked(warpsPerPage)[max(page - 1, 0)]
 
-        val pageDisplay = if (warpPages > 1) "${ChatColor.GRAY}(Page $page/$warpPages)" else ""
+        val clickableWarps = warpList.map { name ->
+            TextComponent(name).also {
+                it.clickEvent = ClickEvent(ClickEvent.Action.RUN_COMMAND, "/warp $name")
+                it.isUnderlined = true
+            }
+        }
 
-        input.sender.send().info(
-            """
-            #${ChatColor.BOLD}Warps $pageDisplay${ChatColor.RESET}
-            #---
-            #${warpList.joinToString(separator = ", ")}
-            """.trimMargin("#"), isMultiLine = true
-        )
+        val clickableWarpList = TextComponent()
+        clickableWarps.forEachIndexed { index, tc ->
+            clickableWarpList.add(tc)
+            if (index < clickableWarps.size - 1) {
+                clickableWarpList.add(", ")
+            }
+        }
+
+        val tc = TextComponent()
+            .add("Warps") { it.isBold = true }
+            .addIf(totalWarpPages > 1, " (Page $page/$totalWarpPages)") { it.color = ChatColor.GRAY }
+            .add("\n---\n")
+            .add(clickableWarpList)
+
+        input.sender.sendMessage(tc)
     }
 
     override fun onTabComplete(sender: CommandSender?, args: List<String>): Iterable<String>? {

--- a/src/main/kotlin/com/projectcitybuild/modules/nameguesser/NameGuesser.kt
+++ b/src/main/kotlin/com/projectcitybuild/modules/nameguesser/NameGuesser.kt
@@ -23,7 +23,7 @@ class NameGuesser {
         }
 
         val closestMatchingString = partialMatches
-            .sortedDescending()
+            .sorted()
             .firstOrNull()
             ?: return null
 

--- a/src/main/kotlin/com/projectcitybuild/modules/textcomponentbuilder/TextComponentBuilder.kt
+++ b/src/main/kotlin/com/projectcitybuild/modules/textcomponentbuilder/TextComponentBuilder.kt
@@ -23,6 +23,12 @@ fun TextComponent.add(message: String, config: ((TextComponent) -> Unit)? = null
     return this
 }
 
+fun TextComponent.addIf(condition: Boolean, message: String, config: ((TextComponent) -> Unit)? = null): TextComponent {
+    if (!condition) return this
+    add(message, config)
+    return this
+}
+
 fun TextComponent.add(number: Int, config: ((TextComponent) -> Unit)? = null): TextComponent {
     return add(number.toString(), config)
 }

--- a/src/main/kotlin/com/projectcitybuild/platforms/bungeecord/BungeecordPlatform.kt
+++ b/src/main/kotlin/com/projectcitybuild/platforms/bungeecord/BungeecordPlatform.kt
@@ -171,7 +171,8 @@ class BungeecordPlatform: Plugin() {
             WarpModule.Bungeecord(
                 proxy,
                 warpFileStorage,
-                NameGuesser()
+                NameGuesser(),
+                config
             ),
         ).forEach { module ->
             module.bungeecordCommands.forEach { commandRegistry?.register(it) }
@@ -199,6 +200,7 @@ class BungeecordPlatform: Plugin() {
             PluginConfig.API_KEY,
             PluginConfig.API_BASE_URL,
             PluginConfig.API_IS_LOGGING_ENABLED,
+            PluginConfig.WARPS_PER_PAGE,
         )
 
         // TODO


### PR DESCRIPTION
* Sorts warp list alphabetically (A to Z)
* Warps can now be clicked to run `/warp <name>`
* "Number of warps per page" can be changed via the plugin config