### PR TITLE
Add TP toggling

### DIFF
--- a/src/main/kotlin/com/projectcitybuild/entities/PlayerConfig.kt
+++ b/src/main/kotlin/com/projectcitybuild/entities/PlayerConfig.kt
@@ -8,7 +8,7 @@ import java.util.*
 data class PlayerConfig(
     val uuid: SerializableUUID,
     var isMuted: Boolean = false,
-    val isAllowingTPs: Boolean = true,
+    var isAllowingTPs: Boolean = true,
     var chatPrefix: String = "",
     var chatSuffix: String = "",
     var chatGroups: String = "",

--- a/src/main/kotlin/com/projectcitybuild/features/teleporting/TeleportModule.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/teleporting/TeleportModule.kt
@@ -2,11 +2,8 @@ package com.projectcitybuild.features.teleporting
 
 import com.projectcitybuild.core.contracts.BungeecordFeatureModule
 import com.projectcitybuild.core.contracts.SpigotFeatureModule
+import com.projectcitybuild.features.teleporting.commands.*
 import com.projectcitybuild.platforms.bungeecord.environment.BungeecordCommand
-import com.projectcitybuild.features.teleporting.commands.TPCommand
-import com.projectcitybuild.features.teleporting.commands.TPHereCommand
-import com.projectcitybuild.features.teleporting.commands.TPOCommand
-import com.projectcitybuild.features.teleporting.commands.TPToggleCommand
 import com.projectcitybuild.features.teleporting.subchannels.AwaitJoinTeleportChannelListener
 import com.projectcitybuild.features.teleporting.subchannels.ImmediateTeleportChannelListener
 import com.projectcitybuild.modules.channels.spigot.SpigotSubChannelListener
@@ -26,8 +23,9 @@ class TeleportModule {
     ): BungeecordFeatureModule {
         override val bungeecordCommands: Array<BungeecordCommand> = arrayOf(
             TPCommand(proxyServer, playerConfigRepository, nameGuesser),
-            TPHereCommand(proxyServer, nameGuesser),
+            TPHereCommand(proxyServer, playerConfigRepository, nameGuesser),
             TPOCommand(proxyServer, nameGuesser),
+            TPOHereCommand(proxyServer, nameGuesser),
             TPToggleCommand(playerConfigRepository),
         )
     }

--- a/src/main/kotlin/com/projectcitybuild/features/teleporting/TeleportModule.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/teleporting/TeleportModule.kt
@@ -28,7 +28,7 @@ class TeleportModule {
             TPCommand(proxyServer, playerConfigRepository, nameGuesser),
             TPHereCommand(proxyServer, nameGuesser),
             TPOCommand(proxyServer, nameGuesser),
-//            TPToggleCommand(proxyServer, playerConfigRepository),
+            TPToggleCommand(playerConfigRepository),
         )
     }
 

--- a/src/main/kotlin/com/projectcitybuild/features/teleporting/commands/TPHereCommand.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/teleporting/commands/TPHereCommand.kt
@@ -7,11 +7,13 @@ import com.projectcitybuild.platforms.bungeecord.MessageToSpigot
 import com.projectcitybuild.platforms.bungeecord.environment.BungeecordCommand
 import com.projectcitybuild.platforms.bungeecord.environment.BungeecordCommandInput
 import com.projectcitybuild.modules.textcomponentbuilder.send
+import com.projectcitybuild.old_modules.playerconfig.PlayerConfigRepository
 import net.md_5.bungee.api.CommandSender
 import net.md_5.bungee.api.ProxyServer
 
 class TPHereCommand(
     private val proxyServer: ProxyServer,
+    private val playerConfigRepository: PlayerConfigRepository,
     private val nameGuesser: NameGuesser
 ): BungeecordCommand {
 
@@ -32,6 +34,12 @@ class TPHereCommand(
         val targetPlayer = nameGuesser.guessClosest(targetPlayerName, proxyServer.players) { it.name }
         if (targetPlayer == null) {
             input.sender.send().error("Player $targetPlayerName not found")
+            return
+        }
+
+        val targetPlayerConfig = playerConfigRepository.get(targetPlayer.uniqueId)
+        if (!targetPlayerConfig.isAllowingTPs) {
+            input.sender.send().error("$targetPlayerName is disallowing teleports")
             return
         }
 

--- a/src/main/kotlin/com/projectcitybuild/features/teleporting/commands/TPOHereCommand.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/teleporting/commands/TPOHereCommand.kt
@@ -10,14 +10,14 @@ import com.projectcitybuild.modules.textcomponentbuilder.send
 import net.md_5.bungee.api.CommandSender
 import net.md_5.bungee.api.ProxyServer
 
-class TPOCommand(
+class TPOHereCommand(
     private val proxyServer: ProxyServer,
     private val nameGuesser: NameGuesser
 ): BungeecordCommand {
 
-    override val label: String = "tpo"
-    override val permission = "pcbridge.tpo.use"
-    override val usageHelp = "/tpo <name>"
+    override val label: String = "tphere"
+    override val permission = "pcbridge.tpo.here"
+    override val usageHelp = "/tpohere <name>"
 
     override suspend fun execute(input: BungeecordCommandInput) {
         if (input.player == null) {
@@ -46,13 +46,13 @@ class TPOCommand(
             targetServer.info,
             subChannel,
             arrayOf(
+                targetPlayer.uniqueId.toString(),
                 input.player.uniqueId.toString(),
-                targetPlayer.uniqueId.toString()
             )
         ).send()
 
         if (!isTargetPlayerOnSameServer) {
-            input.player.connect(targetServer.info)
+            targetPlayer.connect(input.player.server.info)
         }
     }
 

--- a/src/main/kotlin/com/projectcitybuild/features/warps/commands/WarpsCommand.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/warps/commands/WarpsCommand.kt
@@ -59,7 +59,9 @@ class WarpsCommand(
 
         val tc = TextComponent()
             .add("Warps") { it.isBold = true }
-            .addIf(totalWarpPages > 1, " (Page $page/$totalWarpPages)") { it.color = ChatColor.GRAY }
+            .addIf(totalWarpPages > 1, " ($page/$totalWarpPages)") {
+                it.color = ChatColor.GRAY
+            }
             .add("\n---\n")
             .add(clickableWarpList)
 

--- a/src/main/kotlin/com/projectcitybuild/platforms/bungeecord/environment/BungeecordCommandRegistry.kt
+++ b/src/main/kotlin/com/projectcitybuild/platforms/bungeecord/environment/BungeecordCommandRegistry.kt
@@ -54,22 +54,22 @@ class BungeecordCommandRegistry constructor(
                         sender = sender,
                         args = args
                     )
-                    runCatching {
-                        CoroutineScope(Dispatchers.IO).launch {
+                    CoroutineScope(Dispatchers.IO).launch {
+                        runCatching {
                             command.execute(input)
-                        }
-                    }.onFailure { throwable ->
-                        if (throwable is InvalidCommandArgumentsException) {
-                            sender.sendMessage(
-                                TextComponent(command.usageHelp).also {
-                                    it.color = ChatColor.GRAY
-                                    it.isItalic = true
-                                }
-                            )
-                        } else {
-                            sender.send().error(throwable.message ?: "An internal error occurred performing your command")
-                            throwable.message?.let { logger.fatal(it) }
-                            throwable.printStackTrace()
+                        }.onFailure { throwable ->
+                            if (throwable is InvalidCommandArgumentsException) {
+                                sender.sendMessage(
+                                    TextComponent(command.usageHelp).also {
+                                        it.color = ChatColor.GRAY
+                                        it.isItalic = true
+                                    }
+                                )
+                            } else {
+                                sender.send().error(throwable.message ?: "An internal error occurred performing your command")
+                                throwable.message?.let { logger.fatal(it) }
+                                throwable.printStackTrace()
+                            }
                         }
                     }
                     true

--- a/src/main/resources/bungee.yml
+++ b/src/main/resources/bungee.yml
@@ -42,9 +42,15 @@ commands:
   tp:
     description: "Teleports to a given player"
     usage: "/tp <name>"
+  tpo:
+    description: "Teleports to a given player regardless of whether they allow teleports"
+    usage: "/tpo <name>"
   tphere:
-    description: "Teleports a given player to your location"
+    description: "Summons a given player to your location"
     usage: "/tphere <name>"
+  tpohere:
+    description: "Summons a given player to your location regardless of whether they allow teleports"
+    usage: "/tpo <name>"
   unban:
     description: "Allows a banned player to connect to the server"
     usage: "/unban <name>"


### PR DESCRIPTION
* Allows users to toggle on/off whether they allow being teleported to/being summoned.
* Adds a `/tpohere` command, which is the equivalent of `/tphere`, without respecting their toggle state
* Fixes "invalid command" errors not being displayed to the user