### PR TITLE
Fix ban fetch on player connect blocking the main thread

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ plugins {
 }
 
 group 'com.projectcitybuild'
-version '3.0.2'
+version '3.0.3'
 
 apply plugin: 'kotlin'
 apply plugin: 'com.github.johnrengelman.shadow'

--- a/src/main/kotlin/com/projectcitybuild/entities/PlayerConfig.kt
+++ b/src/main/kotlin/com/projectcitybuild/entities/PlayerConfig.kt
@@ -1,6 +1,6 @@
 package com.projectcitybuild.entities
 
-import com.projectcitybuild.old_modules.storage.SerializableUUID
+import com.projectcitybuild.old_modules.storage.serializers.SerializableUUID
 import kotlinx.serialization.Serializable
 import java.util.*
 

--- a/src/main/kotlin/com/projectcitybuild/entities/Warp.kt
+++ b/src/main/kotlin/com/projectcitybuild/entities/Warp.kt
@@ -1,7 +1,7 @@
 package com.projectcitybuild.entities
 
-import com.projectcitybuild.old_modules.storage.SerializableDate
-import com.projectcitybuild.old_modules.storage.SerializableUUID
+import com.projectcitybuild.old_modules.storage.serializers.SerializableDate
+import com.projectcitybuild.old_modules.storage.serializers.SerializableUUID
 import kotlinx.serialization.Serializable
 
 @Serializable

--- a/src/main/kotlin/com/projectcitybuild/features/bans/BanModule.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/bans/BanModule.kt
@@ -11,8 +11,10 @@ import com.projectcitybuild.features.bans.listeners.BanConnectionListener
 import com.projectcitybuild.features.bans.repositories.BanRepository
 import net.md_5.bungee.api.ProxyServer
 import net.md_5.bungee.api.plugin.Listener
+import net.md_5.bungee.api.plugin.Plugin
 
 class BanModule(
+    plugin: Plugin,
     proxyServer: ProxyServer,
     playerUUIDRepository: PlayerUUIDRepository,
     banRepository: BanRepository,
@@ -26,6 +28,6 @@ class BanModule(
     )
 
     override val bungeecordListeners: Array<Listener> = arrayOf(
-        BanConnectionListener(banRepository, logger)
+        BanConnectionListener(plugin, banRepository, logger)
     )
 }

--- a/src/main/kotlin/com/projectcitybuild/features/bans/listeners/BanConnectionListener.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/bans/listeners/BanConnectionListener.kt
@@ -4,40 +4,55 @@ import com.projectcitybuild.core.BungeecordListener
 import com.projectcitybuild.modules.logger.LoggerProvider
 import com.projectcitybuild.features.bans.repositories.BanRepository
 import com.projectcitybuild.platforms.bungeecord.extensions.add
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import net.md_5.bungee.api.ChatColor
 import net.md_5.bungee.api.chat.TextComponent
 import net.md_5.bungee.api.event.LoginEvent
+import net.md_5.bungee.api.plugin.Plugin
 import net.md_5.bungee.event.EventHandler
 import net.md_5.bungee.event.EventPriority
 
 class BanConnectionListener(
+    private val plugin: Plugin,
     private val banRepository: BanRepository,
     private val logger: LoggerProvider
 ) : BungeecordListener {
 
-    // This event is actually asynchronous, so despite the naming
-    // this should not be blocking
     @EventHandler(priority = EventPriority.HIGHEST)
-    fun onPreLoginEvent(event: LoginEvent) = runBlocking {
-        runCatching {
-            banRepository.get(targetPlayerUUID = event.connection.uniqueId)?.let { ban ->
-                event.setCancelReason(TextComponent()
-                    .add("You are currently banned.\n\n") {
-                        it.color = ChatColor.RED
-                        it.isBold = true
-                    }
-                    .add("Reason: ") { it.color = ChatColor.GRAY }
-                    .add((ban.reason ?: "No reason provided") + "\n") { it.color = ChatColor.WHITE }
-                    .add("Expires: ") { it.color = ChatColor.GRAY }
-                    .add(ban.expiresAt?.toString() ?: ("Never" + "\n\n")) { it.color = ChatColor.WHITE }
-                    .add("Appeal @ https://projectcitybuild.com") { it.color = ChatColor.AQUA }
+    fun onPreLoginEvent(event: LoginEvent) {
+        event.registerIntent(plugin)
+
+        CoroutineScope(Dispatchers.IO).launch {
+            runCatching {
+                val ban = banRepository.get(targetPlayerUUID = event.connection.uniqueId)
+                if (ban != null) {
+                    event.setCancelReason(TextComponent()
+                        .add("You are currently banned.\n\n") {
+                            it.color = ChatColor.RED
+                            it.isBold = true
+                        }
+                        .add("Reason: ") { it.color = ChatColor.GRAY }
+                        .add((ban.reason ?: "No reason provided") + "\n") { it.color = ChatColor.WHITE }
+                        .add("Expires: ") { it.color = ChatColor.GRAY }
+                        .add(ban.expiresAt?.toString() ?: ("Never" + "\n\n")) { it.color = ChatColor.WHITE }
+                        .add("Appeal @ https://projectcitybuild.com") { it.color = ChatColor.AQUA }
+                    )
+                    event.isCancelled = true
+                }
+            }
+            .onFailure { throwable ->
+                throwable.message?.let { logger.fatal(it) }
+                throwable.printStackTrace()
+
+                // If something goes wrong, better not to let players in
+                event.setCancelReason(
+                    TextComponent("An error occurred while contacting the PCB authentication server. Please try again later")
                 )
                 event.isCancelled = true
             }
-        }.onFailure { throwable ->
-            throwable.message?.let { logger.fatal(it) }
-            throwable.printStackTrace()
+            .also { event.completeIntent(plugin) }
         }
     }
 }

--- a/src/main/kotlin/com/projectcitybuild/features/chat/commands/IgnoreCommand.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/chat/commands/IgnoreCommand.kt
@@ -3,7 +3,7 @@ package com.projectcitybuild.features.chat.commands
 import com.projectcitybuild.core.InvalidCommandArgumentsException
 import com.projectcitybuild.old_modules.playerconfig.PlayerConfigRepository
 import com.projectcitybuild.modules.playeruuid.PlayerUUIDRepository
-import com.projectcitybuild.old_modules.storage.SerializableUUID
+import com.projectcitybuild.old_modules.storage.serializers.SerializableUUID
 import com.projectcitybuild.platforms.bungeecord.environment.BungeecordCommand
 import com.projectcitybuild.platforms.bungeecord.environment.BungeecordCommandInput
 import com.projectcitybuild.modules.textcomponentbuilder.send

--- a/src/main/kotlin/com/projectcitybuild/features/hub/subchannels/IncomingSetHubListener.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/hub/subchannels/IncomingSetHubListener.kt
@@ -5,8 +5,8 @@ import com.projectcitybuild.entities.SubChannel
 import com.projectcitybuild.entities.Warp
 import com.projectcitybuild.modules.channels.bungeecord.BungeecordSubChannelListener
 import com.projectcitybuild.old_modules.storage.HubFileStorage
-import com.projectcitybuild.old_modules.storage.SerializableDate
-import com.projectcitybuild.old_modules.storage.SerializableUUID
+import com.projectcitybuild.old_modules.storage.serializers.SerializableDate
+import com.projectcitybuild.old_modules.storage.serializers.SerializableUUID
 import com.projectcitybuild.modules.textcomponentbuilder.send
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers

--- a/src/main/kotlin/com/projectcitybuild/features/warps/commands/WarpsCommand.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/warps/commands/WarpsCommand.kt
@@ -12,7 +12,9 @@ import com.projectcitybuild.platforms.bungeecord.extensions.addIf
 import net.md_5.bungee.api.ChatColor
 import net.md_5.bungee.api.CommandSender
 import net.md_5.bungee.api.chat.ClickEvent
+import net.md_5.bungee.api.chat.HoverEvent
 import net.md_5.bungee.api.chat.TextComponent
+import net.md_5.bungee.api.chat.hover.content.Text
 import kotlin.math.ceil
 import kotlin.math.max
 import kotlin.math.min
@@ -45,6 +47,7 @@ class WarpsCommand(
         val clickableWarps = warpList.map { name ->
             TextComponent(name).also {
                 it.clickEvent = ClickEvent(ClickEvent.Action.RUN_COMMAND, "/warp $name")
+                it.hoverEvent = HoverEvent(HoverEvent.Action.SHOW_TEXT, Text("/warp $name"))
                 it.isUnderlined = true
             }
         }

--- a/src/main/kotlin/com/projectcitybuild/features/warps/subchannels/IncomingSetWarpListener.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/warps/subchannels/IncomingSetWarpListener.kt
@@ -4,8 +4,8 @@ import com.google.common.io.ByteArrayDataInput
 import com.projectcitybuild.entities.SubChannel
 import com.projectcitybuild.entities.Warp
 import com.projectcitybuild.modules.channels.bungeecord.BungeecordSubChannelListener
-import com.projectcitybuild.old_modules.storage.SerializableDate
-import com.projectcitybuild.old_modules.storage.SerializableUUID
+import com.projectcitybuild.old_modules.storage.serializers.SerializableDate
+import com.projectcitybuild.old_modules.storage.serializers.SerializableUUID
 import com.projectcitybuild.old_modules.storage.WarpFileStorage
 import com.projectcitybuild.modules.textcomponentbuilder.send
 import kotlinx.coroutines.CoroutineScope

--- a/src/main/kotlin/com/projectcitybuild/old_modules/storage/serializers/DateSerializer.kt
+++ b/src/main/kotlin/com/projectcitybuild/old_modules/storage/serializers/DateSerializer.kt
@@ -1,4 +1,4 @@
-package com.projectcitybuild.old_modules.storage
+package com.projectcitybuild.old_modules.storage.serializers
 
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable

--- a/src/main/kotlin/com/projectcitybuild/old_modules/storage/serializers/UUIDSerializer.kt
+++ b/src/main/kotlin/com/projectcitybuild/old_modules/storage/serializers/UUIDSerializer.kt
@@ -1,4 +1,4 @@
-package com.projectcitybuild.old_modules.storage
+package com.projectcitybuild.old_modules.storage.serializers
 
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable

--- a/src/main/kotlin/com/projectcitybuild/platforms/bungeecord/BungeecordPlatform.kt
+++ b/src/main/kotlin/com/projectcitybuild/platforms/bungeecord/BungeecordPlatform.kt
@@ -136,6 +136,7 @@ class BungeecordPlatform: Plugin() {
 
         arrayOf(
             BanModule(
+                plugin = this,
                 proxy,
                 playerUUIDRepository,
                 banRepository,

--- a/src/main/kotlin/com/projectcitybuild/platforms/bungeecord/environment/BungeecordListenerRegistry.kt
+++ b/src/main/kotlin/com/projectcitybuild/platforms/bungeecord/environment/BungeecordListenerRegistry.kt
@@ -3,7 +3,6 @@ package com.projectcitybuild.platforms.bungeecord.environment
 import com.projectcitybuild.modules.logger.LoggerProvider
 import net.md_5.bungee.api.plugin.Listener
 import net.md_5.bungee.api.plugin.Plugin
-import org.bukkit.event.HandlerList
 
 class BungeecordListenerRegistry constructor(
         private val plugin: Plugin,
@@ -19,7 +18,7 @@ class BungeecordListenerRegistry constructor(
     }
 
     fun unregisterAll() {
-        HandlerList.unregisterAll()
+        plugin.proxy.pluginManager?.unregisterListeners(plugin)
         logger.verbose("Unregistered all listeners")
     }
 }

--- a/src/main/resources/bungee.yml
+++ b/src/main/resources/bungee.yml
@@ -1,6 +1,6 @@
 name: PCBridge
 main: com.projectcitybuild.platforms.bungeecord.BungeecordPlatform
-version: 3.0.2
+version: 3.0.3
 author: _andy
 
 softDepends: ["LuckPerms"]

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,6 +1,6 @@
 main: com.projectcitybuild.platforms.spigot.SpigotPlatform
 name: PCBridge
-version: 3.0.2
+version: 3.0.3
 softdepend:
   - LuckPerms
 


### PR DESCRIPTION
* Fixes the ban fetch blocking the main thread upon `LoginEvent`, by utilising Bungeecord's event Intent system
* Fixes listeners not being unregistered upon plugin disable (not really an issue unless you're running `/reload` for some reason)
* Fixes the namespace of some serializers