### PR TITLE
Send a welcome message upon joining

### DIFF
--- a/src/main/kotlin/com/projectcitybuild/features/joinmessage/JoinMessageModule.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/joinmessage/JoinMessageModule.kt
@@ -4,6 +4,7 @@ import com.projectcitybuild.core.BungeecordListener
 import com.projectcitybuild.core.SpigotListener
 import com.projectcitybuild.core.contracts.BungeecordFeatureModule
 import com.projectcitybuild.core.contracts.SpigotFeatureModule
+import com.projectcitybuild.features.joinmessage.listeners.FirstTimeJoinMessageListener
 import com.projectcitybuild.features.joinmessage.listeners.NetworkJoinMessageListener
 import com.projectcitybuild.features.joinmessage.listeners.SupressJoinMessageListener
 import com.projectcitybuild.features.joinmessage.listeners.WelcomeMessageListener
@@ -14,10 +15,12 @@ class JoinMessageModule {
     class Bungeecord @Inject constructor(
         networkJoinMessageListener: NetworkJoinMessageListener,
         welcomeMessageListener: WelcomeMessageListener,
+        firstTimeJoinMessageListener: FirstTimeJoinMessageListener,
     ): BungeecordFeatureModule {
         override val bungeecordListeners: Array<BungeecordListener> = arrayOf(
             networkJoinMessageListener,
             welcomeMessageListener,
+            firstTimeJoinMessageListener,
         )
     }
 

--- a/src/main/kotlin/com/projectcitybuild/features/joinmessage/JoinMessageModule.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/joinmessage/JoinMessageModule.kt
@@ -6,15 +6,18 @@ import com.projectcitybuild.core.contracts.BungeecordFeatureModule
 import com.projectcitybuild.core.contracts.SpigotFeatureModule
 import com.projectcitybuild.features.joinmessage.listeners.NetworkJoinMessageListener
 import com.projectcitybuild.features.joinmessage.listeners.SupressJoinMessageListener
+import com.projectcitybuild.features.joinmessage.listeners.WelcomeMessageListener
 import javax.inject.Inject
 
 class JoinMessageModule {
 
     class Bungeecord @Inject constructor(
         networkJoinMessageListener: NetworkJoinMessageListener,
+        welcomeMessageListener: WelcomeMessageListener,
     ): BungeecordFeatureModule {
         override val bungeecordListeners: Array<BungeecordListener> = arrayOf(
             networkJoinMessageListener,
+            welcomeMessageListener,
         )
     }
 

--- a/src/main/kotlin/com/projectcitybuild/features/joinmessage/events/FirstTimeJoinEvent.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/joinmessage/events/FirstTimeJoinEvent.kt
@@ -1,0 +1,6 @@
+package com.projectcitybuild.features.joinmessage.events
+
+import net.md_5.bungee.api.connection.ProxiedPlayer
+import net.md_5.bungee.api.plugin.Event as BungeecordEvent
+
+class FirstTimeJoinEvent(val player: ProxiedPlayer): BungeecordEvent()

--- a/src/main/kotlin/com/projectcitybuild/features/joinmessage/listeners/FirstTimeJoinMessageListener.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/joinmessage/listeners/FirstTimeJoinMessageListener.kt
@@ -2,6 +2,7 @@ package com.projectcitybuild.features.joinmessage.listeners
 
 import com.projectcitybuild.core.BungeecordListener
 import com.projectcitybuild.features.joinmessage.events.FirstTimeJoinEvent
+import com.projectcitybuild.modules.logger.PlatformLogger
 import com.projectcitybuild.platforms.bungeecord.extensions.add
 import net.md_5.bungee.api.ChatColor
 import net.md_5.bungee.api.ProxyServer
@@ -10,11 +11,14 @@ import net.md_5.bungee.event.EventHandler
 import javax.inject.Inject
 
 class FirstTimeJoinMessageListener @Inject constructor(
-    private val proxyServer: ProxyServer
+    private val proxyServer: ProxyServer,
+    private val logger: PlatformLogger,
 ): BungeecordListener {
 
     @EventHandler
     fun onFirstTimeJoin(event: FirstTimeJoinEvent) {
+        logger.debug("Sending first-time welcome message for ${event.player.name}")
+
         proxyServer.broadcast(
             TextComponent()
                 .add("✦ Welcome ") {

--- a/src/main/kotlin/com/projectcitybuild/features/joinmessage/listeners/FirstTimeJoinMessageListener.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/joinmessage/listeners/FirstTimeJoinMessageListener.kt
@@ -1,0 +1,31 @@
+package com.projectcitybuild.features.joinmessage.listeners
+
+import com.projectcitybuild.core.BungeecordListener
+import com.projectcitybuild.features.joinmessage.events.FirstTimeJoinEvent
+import com.projectcitybuild.platforms.bungeecord.extensions.add
+import net.md_5.bungee.api.ChatColor
+import net.md_5.bungee.api.ProxyServer
+import net.md_5.bungee.api.chat.TextComponent
+import net.md_5.bungee.event.EventHandler
+import javax.inject.Inject
+
+class FirstTimeJoinMessageListener @Inject constructor(
+    private val proxyServer: ProxyServer
+): BungeecordListener {
+
+    @EventHandler
+    fun onFirstTimeJoin(event: FirstTimeJoinEvent) {
+        proxyServer.broadcast(
+            TextComponent()
+                .add("✦ Welcome ") {
+                    it.color = ChatColor.LIGHT_PURPLE
+                }
+                .add(event.player.name) {
+                    it.color = ChatColor.WHITE
+                }
+                .add(" to the server!") {
+                    it.color = ChatColor.LIGHT_PURPLE
+                }
+        )
+    }
+}

--- a/src/main/kotlin/com/projectcitybuild/features/joinmessage/listeners/WelcomeMessageListener.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/joinmessage/listeners/WelcomeMessageListener.kt
@@ -1,0 +1,33 @@
+package com.projectcitybuild.features.joinmessage.listeners
+
+import com.projectcitybuild.core.BungeecordListener
+import com.projectcitybuild.platforms.bungeecord.extensions.add
+import net.md_5.bungee.api.ProxyServer
+import net.md_5.bungee.api.chat.TextComponent
+import net.md_5.bungee.api.event.PostLoginEvent
+import net.md_5.bungee.event.EventHandler
+import javax.inject.Inject
+
+class WelcomeMessageListener @Inject constructor(
+    private val proxyServer: ProxyServer
+): BungeecordListener {
+
+    @EventHandler
+    fun onPostLoginEvent(event: PostLoginEvent) {
+        val onlinePlayerCount = proxyServer.players.size
+
+        event.player.sendMessage(
+            TextComponent().add(
+                TextComponent.fromLegacyText("""
+                    #&3Welcome to &f&lPROJECT &6&lCITY &9&lBUILD
+                    #
+                    #&3Type &c/register &3to become a member.
+                    #&3Type &c/list&6 &3to see who else is online.
+                    #&3Players online:&c $onlinePlayerCount
+                    #
+                    #&f&lAsk our staff if you have any questions.
+                """.trimMargin("#"))
+            )
+        )
+    }
+}

--- a/src/main/kotlin/com/projectcitybuild/features/joinmessage/listeners/WelcomeMessageListener.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/joinmessage/listeners/WelcomeMessageListener.kt
@@ -19,13 +19,13 @@ class WelcomeMessageListener @Inject constructor(
         event.player.sendMessage(
             TextComponent().add(
                 TextComponent.fromLegacyText("""
-                    #&3Welcome to &f&lPROJECT &6&lCITY &9&lBUILD
+                    #§3Welcome to §f§lPROJECT §6§lCITY §9§lBUILD
                     #
-                    #&3Type &c/register &3to become a member.
-                    #&3Type &c/list&6 &3to see who else is online.
-                    #&3Players online:&c $onlinePlayerCount
+                    #§3Type §c/register §3to become a member.
+                    #§3Type §c/list§6 §3to see who else is online.
+                    #§3Players online:§c $onlinePlayerCount
                     #
-                    #&f&lAsk our staff if you have any questions.
+                    #§f§lAsk our staff if you have any questions.
                 """.trimMargin("#"))
             )
         )

--- a/src/main/kotlin/com/projectcitybuild/features/playercache/listeners/PlayerCacheListener.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/playercache/listeners/PlayerCacheListener.kt
@@ -2,6 +2,7 @@ package com.projectcitybuild.features.playercache.listeners
 
 import com.projectcitybuild.core.BungeecordListener
 import com.projectcitybuild.features.joinmessage.events.FirstTimeJoinEvent
+import com.projectcitybuild.modules.logger.PlatformLogger
 import com.projectcitybuild.modules.playerconfig.PlayerConfigCache
 import com.projectcitybuild.modules.playerconfig.PlayerConfigRepository
 import net.md_5.bungee.api.event.PlayerDisconnectEvent
@@ -15,6 +16,7 @@ class PlayerCacheListener @Inject constructor(
     private val plugin: Plugin,
     private val playerCache: PlayerConfigCache,
     private val playerConfigRepository: PlayerConfigRepository,
+    private val logger: PlatformLogger,
 ): BungeecordListener {
 
     @EventHandler
@@ -22,6 +24,8 @@ class PlayerCacheListener @Inject constructor(
         val uuid = event.player.uniqueId
 
         if (playerConfigRepository.get(uuid) == null) {
+            logger.debug("No player config found for $uuid. Generating new one...")
+
             plugin.proxy.pluginManager.callEvent(
                 FirstTimeJoinEvent(event.player)
             )

--- a/src/main/kotlin/com/projectcitybuild/features/playercache/listeners/PlayerCacheListener.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/playercache/listeners/PlayerCacheListener.kt
@@ -1,15 +1,18 @@
 package com.projectcitybuild.features.playercache.listeners
 
 import com.projectcitybuild.core.BungeecordListener
+import com.projectcitybuild.features.joinmessage.events.FirstTimeJoinEvent
 import com.projectcitybuild.modules.playerconfig.PlayerConfigCache
 import com.projectcitybuild.modules.playerconfig.PlayerConfigRepository
 import net.md_5.bungee.api.event.PlayerDisconnectEvent
 import net.md_5.bungee.api.event.PostLoginEvent
+import net.md_5.bungee.api.plugin.Plugin
 import net.md_5.bungee.event.EventHandler
 import java.time.LocalDateTime
 import javax.inject.Inject
 
 class PlayerCacheListener @Inject constructor(
+    private val plugin: Plugin,
     private val playerCache: PlayerConfigCache,
     private val playerConfigRepository: PlayerConfigRepository,
 ): BungeecordListener {
@@ -19,6 +22,9 @@ class PlayerCacheListener @Inject constructor(
         val uuid = event.player.uniqueId
 
         if (playerConfigRepository.get(uuid) == null) {
+            plugin.proxy.pluginManager.callEvent(
+                FirstTimeJoinEvent(event.player)
+            )
             playerConfigRepository.add(
                 uuid = uuid,
                 isMuted = false,


### PR DESCRIPTION
* Broadcasts a welcome message when a player joins for the first time
* Sends a player a general info message when they join the network (to replace Essentials' version which doesn't work properly on Bungeecord)

Closes #57 