### PR TITLE
Add prefixed Bungeecord commands

### DIFF
--- a/src/main/kotlin/com/projectcitybuild/platforms/bungeecord/environment/BungeecordCommandRegistry.kt
+++ b/src/main/kotlin/com/projectcitybuild/platforms/bungeecord/environment/BungeecordCommandRegistry.kt
@@ -42,7 +42,10 @@ class BungeecordCommandRegistry @Inject constructor(
     }
 
     fun register(command: BungeecordCommand) {
-        command.aliases.plus(command.label).forEach { alias ->
+        val labels = command.aliases.plus(command.label)
+        val prefixedLabels = labels.map { "pcbridge:$it" } // Replicate Spigot's command prefixing in-case of conflicts
+
+        labels.plus(prefixedLabels).forEach { alias ->
             plugin.proxy.pluginManager.registerCommand(plugin, CommandProxy(
                 alias,
                 execute = { sender, args ->


### PR DESCRIPTION
Adds a `pcbridge:` prefix to each Bungeecord command registered (eg. `pcbridge:tp`).
This replicates the same behaviour of Spigot and helps in situations of conflicting commands