### PR TITLE
Change CI java distro to Temurin

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           java-version: '16'
-          distribution: 'adopt'
+          distribution: 'temurin'
       - uses: actions/cache@v2
         with:
           path: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
       uses: actions/setup-java@v2
       with:
         java-version: '16'
-        distribution: 'adopt'
+        distribution: 'temurin'
 
     - name: Cache Gradle packages
       uses: actions/cache@v2


### PR DESCRIPTION
[AdoptOpenJDK is dead](https://blog.adoptopenjdk.net/2021/08/goodbye-adoptopenjdk-hello-adoptium/), swapped CI Java version to use Adoptium's Temurin binaries instead.