### PR TITLE
Fix null exception thrown when kicking an offline player

### DIFF
--- a/src/main/kotlin/com/projectcitybuild/modules/proxyadapter/kick/BungeecordPlayerKicker.kt
+++ b/src/main/kotlin/com/projectcitybuild/modules/proxyadapter/kick/BungeecordPlayerKicker.kt
@@ -21,7 +21,7 @@ class BungeecordPlayerKicker @Inject constructor(
     override fun kick(playerUUID: UUID, reason: String, context: PlayerKicker.KickContext) {
         proxyServer
             .getPlayer(playerUUID)
-            .disconnect(makeTextComponent(reason, context))
+            ?.disconnect(makeTextComponent(reason, context))
     }
 
     private fun makeTextComponent(message: String, context: PlayerKicker.KickContext): TextComponent {


### PR DESCRIPTION
Fixes an exception being thrown when attempting to ban/kick a player who is offline

Based on report from Discord
![image](https://user-images.githubusercontent.com/7236312/151957382-1cd7d67f-72f0-479e-a673-6ba4473951a7.png)
