### PR TITLE
Add missing /tptoggle command to bungeecord.yml

### DIFF
--- a/src/main/resources/bungee.yml
+++ b/src/main/resources/bungee.yml
@@ -48,6 +48,9 @@ commands:
   tpohere:
     description: "Summons a given player to your location regardless of whether they allow teleports"
     usage: "/tpo <name>"
+  tptoggle:
+    description: "Allows/disallows players to teleport/summon you"
+    usage: "/tptoggle [on|off]"
   unban:
     description: "Allows a banned player to connect to the server"
     usage: "/unban <name>"


### PR DESCRIPTION
`/tptoggle` is missing from in-game because `bungeecord.yml` doesn't contain an entry for `tptoggle`