### PR TITLE
Allow `/tpo` teleport messages to be supressed

### DIFF
--- a/src/main/kotlin/com/projectcitybuild/entities/QueuedTeleport.kt
+++ b/src/main/kotlin/com/projectcitybuild/entities/QueuedTeleport.kt
@@ -8,6 +8,7 @@ data class QueuedTeleport(
     val targetPlayerUUID: UUID,
     val targetServerName: String,
     val teleportType: TeleportType,
+    val isSilentTeleport: Boolean,
     val createdAt: LocalDateTime,
 )
 

--- a/src/main/kotlin/com/projectcitybuild/entities/migrations/20220207_add_teleport_message_silencing.kt
+++ b/src/main/kotlin/com/projectcitybuild/entities/migrations/20220207_add_teleport_message_silencing.kt
@@ -1,0 +1,19 @@
+package com.projectcitybuild.entities.migrations
+
+import co.aikar.idb.HikariPooledDatabase
+import com.projectcitybuild.modules.database.DatabaseMigration
+
+class `20220207_add_teleport_message_silencing`: DatabaseMigration {
+    override val description = "Add a column to silence teleport messages"
+
+    override fun execute(database: HikariPooledDatabase) {
+        database.executeUpdate(
+            """
+                    |ALTER TABLE queued_teleports 
+                    |   ADD `is_silent_tp` TINYINT(1) DEFAULT 0 NOT NULL AFTER `teleport_type`;
+                    """
+                .trimMargin("|")
+                .replace("\n", "")
+        )
+    }
+}

--- a/src/main/kotlin/com/projectcitybuild/features/teleporting/PlayerTeleporter.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/teleporting/PlayerTeleporter.kt
@@ -3,8 +3,8 @@ package com.projectcitybuild.features.teleporting
 import com.projectcitybuild.core.utilities.Failure
 import com.projectcitybuild.core.utilities.Result
 import com.projectcitybuild.core.utilities.Success
-import com.projectcitybuild.entities.SubChannel
 import com.projectcitybuild.entities.QueuedTeleport
+import com.projectcitybuild.entities.SubChannel
 import com.projectcitybuild.entities.TeleportType
 import com.projectcitybuild.features.teleporting.repositories.QueuedTeleportRepository
 import com.projectcitybuild.modules.playerconfig.PlayerConfigRepository
@@ -24,7 +24,8 @@ class PlayerTeleporter @Inject constructor(
     fun teleport(
         player: ProxiedPlayer,
         destinationPlayer: ProxiedPlayer,
-        shouldCheckAllowingTP: Boolean
+        shouldCheckAllowingTP: Boolean,
+        shouldSupressTeleportedMessage: Boolean,
     ): Result<Unit, FailureReason> {
         if (shouldCheckAllowingTP) {
             val targetPlayerConfig = playerConfigRepository.get(destinationPlayer.uniqueId)!!
@@ -42,7 +43,8 @@ class PlayerTeleporter @Inject constructor(
                 arrayOf(
                     player.uniqueId.toString(),
                     destinationPlayer.uniqueId.toString(),
-                    false,
+                    false, // isSummon
+                    shouldSupressTeleportedMessage,
                 )
             ).send()
         } else {
@@ -52,6 +54,7 @@ class PlayerTeleporter @Inject constructor(
                     targetPlayerUUID = destinationPlayer.uniqueId,
                     targetServerName = destinationServer.name,
                     teleportType = TeleportType.TP,
+                    isSilentTeleport = shouldSupressTeleportedMessage,
                     createdAt = LocalDateTime.now()
                 )
             )
@@ -71,7 +74,8 @@ class PlayerTeleporter @Inject constructor(
     fun summon(
         summonedPlayer: ProxiedPlayer,
         destinationPlayer: ProxiedPlayer,
-        shouldCheckAllowingTP: Boolean
+        shouldCheckAllowingTP: Boolean,
+        shouldSupressTeleportedMessage: Boolean,
     ): Result<Unit, FailureReason> {
         if (shouldCheckAllowingTP) {
             val summonedPlayerConfig = playerConfigRepository.get(summonedPlayer.uniqueId)!!
@@ -99,6 +103,7 @@ class PlayerTeleporter @Inject constructor(
                     targetPlayerUUID = destinationPlayer.uniqueId,
                     targetServerName = targetServer.name,
                     teleportType = TeleportType.TP,
+                    isSilentTeleport = shouldSupressTeleportedMessage,
                     createdAt = LocalDateTime.now()
                 )
             )

--- a/src/main/kotlin/com/projectcitybuild/features/teleporting/PlayerTeleporter.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/teleporting/PlayerTeleporter.kt
@@ -94,6 +94,7 @@ class PlayerTeleporter @Inject constructor(
                     summonedPlayer.uniqueId.toString(),
                     destinationPlayer.uniqueId.toString(),
                     true,
+                    shouldSupressTeleportedMessage,
                 )
             ).send()
         } else {

--- a/src/main/kotlin/com/projectcitybuild/features/teleporting/commands/TPAcceptCommand.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/teleporting/commands/TPAcceptCommand.kt
@@ -61,6 +61,7 @@ class TPAcceptCommand @Inject constructor(
                     player = requesterPlayer,
                     destinationPlayer = targetPlayer,
                     shouldCheckAllowingTP = false,
+                    shouldSupressTeleportedMessage = false,
                 )
                 targetPlayer.send().info("Accepted teleport request")
                 requesterPlayer.send().info("${input.player.name} accepted your teleport request")
@@ -70,6 +71,7 @@ class TPAcceptCommand @Inject constructor(
                     summonedPlayer = targetPlayer,
                     destinationPlayer = requesterPlayer,
                     shouldCheckAllowingTP = false,
+                    shouldSupressTeleportedMessage = false,
                 )
                 targetPlayer.send().info("Accepted summon request")
                 requesterPlayer.send().info("${input.player.name} accepted your summon request")

--- a/src/main/kotlin/com/projectcitybuild/features/teleporting/commands/TPCommand.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/teleporting/commands/TPCommand.kt
@@ -45,7 +45,8 @@ class TPCommand @Inject constructor(
         val result = playerTeleporter.teleport(
             player = input.player,
             destinationPlayer = targetPlayer,
-            shouldCheckAllowingTP = true
+            shouldCheckAllowingTP = true,
+            shouldSupressTeleportedMessage = false,
         )
         if (result is Failure) {
             when (result.reason) {

--- a/src/main/kotlin/com/projectcitybuild/features/teleporting/commands/TPHereCommand.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/teleporting/commands/TPHereCommand.kt
@@ -45,7 +45,8 @@ class TPHereCommand @Inject constructor(
         val result = playerTeleporter.summon(
             summonedPlayer = targetPlayer,
             destinationPlayer = input.player,
-            shouldCheckAllowingTP = true
+            shouldCheckAllowingTP = true,
+            shouldSupressTeleportedMessage = false,
         )
         if (result is Failure) {
             when (result.reason) {

--- a/src/main/kotlin/com/projectcitybuild/features/teleporting/commands/TPOCommand.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/teleporting/commands/TPOCommand.kt
@@ -18,15 +18,25 @@ class TPOCommand @Inject constructor(
 
     override val label: String = "tpo"
     override val permission = "pcbridge.tpo.use"
-    override val usageHelp = "/tpo <name>"
+    override val usageHelp = "/tpo <name> [--silent]"
 
     override suspend fun execute(input: BungeecordCommandInput) {
         if (input.player == null) {
             input.sender.send().error("Console cannot use this command")
             return
         }
-        if (input.args.size != 1) {
+        if (input.args.isEmpty() || input.args.size > 2) {
             throw InvalidCommandArgumentsException()
+        }
+
+        var isSilentTP = false
+        if (input.args.size == 2) {
+            if (input.args[1] == "--silent") {
+                isSilentTP = true
+            } else {
+                input.player.send().error("${input.args[1]} is not a valid argument")
+                return
+            }
         }
 
         val targetPlayerName = input.args.first()
@@ -45,7 +55,7 @@ class TPOCommand @Inject constructor(
             player = input.player,
             destinationPlayer = targetPlayer,
             shouldCheckAllowingTP = false,
-            shouldSupressTeleportedMessage = true,
+            shouldSupressTeleportedMessage = isSilentTP,
         )
     }
 
@@ -59,6 +69,8 @@ class TPOCommand @Inject constructor(
                 .map { it.name }
                 .filter { it != sender?.name }
                 .filter { it.lowercase().startsWith(args.first().lowercase()) }
+
+            args.size == 2 -> listOf("--silent")
 
             else -> null
         }

--- a/src/main/kotlin/com/projectcitybuild/features/teleporting/commands/TPOCommand.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/teleporting/commands/TPOCommand.kt
@@ -44,7 +44,8 @@ class TPOCommand @Inject constructor(
         playerTeleporter.teleport(
             player = input.player,
             destinationPlayer = targetPlayer,
-            shouldCheckAllowingTP = false
+            shouldCheckAllowingTP = false,
+            shouldSupressTeleportedMessage = true,
         )
     }
 

--- a/src/main/kotlin/com/projectcitybuild/features/teleporting/commands/TPOHereCommand.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/teleporting/commands/TPOHereCommand.kt
@@ -16,17 +16,27 @@ class TPOHereCommand @Inject constructor(
     private val nameGuesser: NameGuesser
 ): BungeecordCommand {
 
-    override val label: String = "tphere"
+    override val label: String = "tpohere"
     override val permission = "pcbridge.tpo.here"
-    override val usageHelp = "/tpohere <name>"
+    override val usageHelp = "/tpohere <name> [--silent]"
 
     override suspend fun execute(input: BungeecordCommandInput) {
         if (input.player == null) {
             input.sender.send().error("Console cannot use this command")
             return
         }
-        if (input.args.size != 1) {
+        if (input.args.isEmpty() || input.args.size > 2) {
             throw InvalidCommandArgumentsException()
+        }
+
+        var isSilentTP = false
+        if (input.args.size == 2) {
+            if (input.args[1] == "--silent") {
+                isSilentTP = true
+            } else {
+                input.player.send().error("${input.args[1]} is not a valid argument")
+                return
+            }
         }
 
         val targetPlayerName = input.args.first()
@@ -45,7 +55,7 @@ class TPOHereCommand @Inject constructor(
             summonedPlayer = targetPlayer,
             destinationPlayer = input.player,
             shouldCheckAllowingTP = false,
-            shouldSupressTeleportedMessage = true,
+            shouldSupressTeleportedMessage = isSilentTP,
         )
     }
 
@@ -59,6 +69,8 @@ class TPOHereCommand @Inject constructor(
                 .map { it.name }
                 .filter { it != sender?.name }
                 .filter { it.lowercase().startsWith(args.first().lowercase()) }
+
+            args.size == 2 -> listOf("--silent")
 
             else -> null
         }

--- a/src/main/kotlin/com/projectcitybuild/features/teleporting/commands/TPOHereCommand.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/teleporting/commands/TPOHereCommand.kt
@@ -44,7 +44,8 @@ class TPOHereCommand @Inject constructor(
         playerTeleporter.summon(
             summonedPlayer = targetPlayer,
             destinationPlayer = input.player,
-            shouldCheckAllowingTP = false
+            shouldCheckAllowingTP = false,
+            shouldSupressTeleportedMessage = true,
         )
     }
 

--- a/src/main/kotlin/com/projectcitybuild/features/teleporting/listeners/TeleportOnJoinListener.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/teleporting/listeners/TeleportOnJoinListener.kt
@@ -48,12 +48,18 @@ class TeleportOnJoinListener @Inject constructor(
 
         when (queuedTeleport.teleportType) {
             TeleportType.TP -> {
-                destinationPlayer.send().action("${event.player.name} teleported to you")
                 event.player.send().action("Teleported to ${destinationPlayer.name}")
+
+                if (!queuedTeleport.isSilentTeleport) {
+                    destinationPlayer.send().action("${event.player.name} teleported to you")
+                }
             }
             TeleportType.SUMMON -> {
                 destinationPlayer.send().action("You summoned ${event.player.name} to you")
-                event.player.send().action("You were summoned to ${destinationPlayer.name}")
+
+                if (!queuedTeleport.isSilentTeleport) {
+                    event.player.send().action("You were summoned to ${destinationPlayer.name}")
+                }
             }
         }
     }

--- a/src/main/kotlin/com/projectcitybuild/features/teleporting/repositories/QueuedTeleportRepository.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/teleporting/repositories/QueuedTeleportRepository.kt
@@ -14,11 +14,12 @@ class QueuedTeleportRepository @Inject constructor(
             dequeue(queuedTeleport.playerUUID)
         }
         dataSource.database().executeInsert(
-            "INSERT INTO `queued_teleports` VALUES (?, ?, ?, ?, ?)",
+            "INSERT INTO `queued_teleports` VALUES (?, ?, ?, ?, ?, ?)",
             queuedTeleport.playerUUID.toString(),
             queuedTeleport.targetPlayerUUID.toString(),
             queuedTeleport.targetServerName,
             queuedTeleport.teleportType.toString(),
+            if (queuedTeleport.isSilentTeleport) 1 else 0,
             queuedTeleport.createdAt,
         )
     }
@@ -45,6 +46,7 @@ class QueuedTeleportRepository @Inject constructor(
                     "SUMMON" -> TeleportType.SUMMON
                     else -> throw Exception("Unhandled TeleportType: ${row.getString("teleport_type")}")
                 },
+                isSilentTeleport = row.getInt("is_silent_tp") == 1,
                 createdAt = row.get("created_at"),
             )
         }

--- a/src/main/kotlin/com/projectcitybuild/features/teleporting/subchannels/SameServerTeleportChannelListener.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/teleporting/subchannels/SameServerTeleportChannelListener.kt
@@ -21,6 +21,10 @@ class SameServerTeleportChannelListener @Inject constructor(
 
     override fun onSpigotReceivedMessage(player: Player?, stream: ByteArrayDataInput) {
         val targetPlayerUUID = UUID.fromString(stream.readUTF())
+        val destinationPlayerUUID = UUID.fromString(stream.readUTF())
+        val isSummon = stream.readBoolean()
+        val isSilentTP = stream.readBoolean()
+
         val targetPlayer = plugin.server.getPlayer(targetPlayerUUID)
         if (targetPlayer == null) {
             logger.warning("Could not find player. Did they disconnect?")
@@ -31,7 +35,6 @@ class SameServerTeleportChannelListener @Inject constructor(
             PlayerPreSummonEvent(targetPlayer, targetPlayer.location)
         )
 
-        val destinationPlayerUUID = UUID.fromString(stream.readUTF())
         val destinationPlayer = plugin.server.getPlayer(destinationPlayerUUID)
         if (destinationPlayer == null) {
             logger.warning("Could not find destination player. Did they disconnect?")
@@ -42,14 +45,19 @@ class SameServerTeleportChannelListener @Inject constructor(
 
         targetPlayer.teleport(destinationPlayer.location)
 
-        val isSummon = stream.readBoolean()
         if (isSummon) {
             destinationPlayer.send().action("You summoned ${targetPlayer.name} to you")
-            targetPlayer.send().action("You were summoned to ${destinationPlayer.name}")
+
+            if (!isSilentTP) {
+                targetPlayer.send().action("You were summoned to ${destinationPlayer.name}")
+            }
 
         } else {
-            destinationPlayer.send().action("${targetPlayer.name} teleported to you")
             targetPlayer.send().action("Teleported to ${destinationPlayer.name}")
+
+            if (!isSilentTP) {
+                destinationPlayer.send().action("${targetPlayer.name} teleported to you")
+            }
         }
     }
 }

--- a/src/main/kotlin/com/projectcitybuild/modules/database/Migration.kt
+++ b/src/main/kotlin/com/projectcitybuild/modules/database/Migration.kt
@@ -12,6 +12,7 @@ object Migration {
         `20220120_teleport_history`(),
         `20220201_add_hub`(),
         `20220201_add_ip_bans`(),
+        `20220207_add_teleport_message_silencing`(),
     )
 
     fun executeIfNecessary(

--- a/src/test/com/projectcitybuild/features/teleporting/PlayerTeleporterTest.kt
+++ b/src/test/com/projectcitybuild/features/teleporting/PlayerTeleporterTest.kt
@@ -42,7 +42,7 @@ class PlayerTeleporterTest {
             PlayerConfigMock(targetPlayerUUID).apply { isAllowingTPs = false }
         )
 
-        val result = requester.teleport(originPlayer, targetPlayer, true)
+        val result = requester.teleport(originPlayer, targetPlayer, true, false)
 
         assertEquals(result, Failure(PlayerTeleporter.FailureReason.TARGET_PLAYER_DISALLOWS_TP))
     }
@@ -58,7 +58,7 @@ class PlayerTeleporterTest {
             PlayerConfigMock(targetPlayerUUID).apply { isAllowingTPs = false }
         )
 
-        val result = requester.summon(targetPlayer, originPlayer, true)
+        val result = requester.summon(targetPlayer, originPlayer, true, false)
 
         assertEquals(result, Failure(PlayerTeleporter.FailureReason.TARGET_PLAYER_DISALLOWS_TP))
     }


### PR DESCRIPTION
Allows you to specify a `--silent` parameter when using `/tpo` and `/tpohere`.

For example:
 ```
/tpo _andy --silent
/tpohere _andy --silent
```

If specified, a "XXX teleported to you" or "You were summoned to XXX" message will not be sent to the target player.

Fixes #88 