### PR TITLE
Show warps on dynmap

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,11 @@ buildscript {
     repositories {
         mavenCentral()
         gradlePluginPortal()
+
+        maven {
+            name = 'dynmap'
+            url "https://repo.mikeprimm.com/"
+        }
     }
 }
 
@@ -65,6 +70,10 @@ dependencies {
 
     testImplementation 'net.md-5:bungeecord-api:1.16-R0.4' // Needed for mocking in tests
     testImplementation 'org.spigotmc:spigot-api:1.12.2-R0.1-SNAPSHOT' // Needed for mocking in tests
+
+    // dynmap
+    compileOnly 'us.dynmap:dynmap-api:3.3'
+    compileOnly 'us.dynmap:DynmapCoreAPI:3.3'
 
     // Spigot
     compileOnly 'org.spigotmc:spigot-api:1.12.2-R0.1-SNAPSHOT'

--- a/src/main/kotlin/com/projectcitybuild/core/contracts/FeatureModule.kt
+++ b/src/main/kotlin/com/projectcitybuild/core/contracts/FeatureModule.kt
@@ -31,4 +31,5 @@ interface SpigotFeatureModule {
         get() = emptyArray()
 
     fun onEnable() = run { }
+    fun onDisable() = run { }
 }

--- a/src/main/kotlin/com/projectcitybuild/core/contracts/FeatureModule.kt
+++ b/src/main/kotlin/com/projectcitybuild/core/contracts/FeatureModule.kt
@@ -29,4 +29,6 @@ interface SpigotFeatureModule {
 
     val spigotSubChannelListeners: Array<SpigotSubChannelListener>
         get() = emptyArray()
+
+    fun onEnable() = run { }
 }

--- a/src/main/kotlin/com/projectcitybuild/entities/PluginConfig.kt
+++ b/src/main/kotlin/com/projectcitybuild/entities/PluginConfig.kt
@@ -31,6 +31,8 @@ sealed class PluginConfig {
 
         val TP_REQUEST_AUTO_EXPIRE_SECONDS = "teleports.requests.auto_expiry_in_seconds" defaultTo 20
 
+        val INTEGRATION_DYNMAP_WARP_ICON = "integrations.dynmap.warp_icon" defaultTo "portal"
+
         val TIME_TIMEZONE = "time.timezone" defaultTo "UTC"
         val TIME_LOCALE = "time.locale" defaultTo "en-us"
 

--- a/src/main/kotlin/com/projectcitybuild/features/warps/WarpModule.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/warps/WarpModule.kt
@@ -2,6 +2,7 @@ package com.projectcitybuild.features.warps
 
 import com.projectcitybuild.core.SpigotListener
 import com.projectcitybuild.core.contracts.SpigotFeatureModule
+import com.projectcitybuild.features.warps.adapters.dynmap.DynmapMarkerAdapter
 import com.projectcitybuild.features.warps.commands.DelWarpCommand
 import com.projectcitybuild.features.warps.commands.SetWarpCommand
 import com.projectcitybuild.features.warps.commands.WarpCommand
@@ -16,6 +17,7 @@ class WarpModule @Inject constructor(
     warpCommand: WarpCommand,
     warpsCommand: WarpsCommand,
     warpOnJoinListener: WarpOnJoinListener,
+    private val dynmapMarkerAdapter: DynmapMarkerAdapter,
 ): SpigotFeatureModule {
 
     override val spigotCommands: Array<SpigotCommand> = arrayOf(
@@ -28,4 +30,8 @@ class WarpModule @Inject constructor(
     override val spigotListeners: Array<SpigotListener> = arrayOf(
         warpOnJoinListener,
     )
+
+    override fun onEnable() {
+        dynmapMarkerAdapter.enable()
+    }
 }

--- a/src/main/kotlin/com/projectcitybuild/features/warps/WarpModule.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/warps/WarpModule.kt
@@ -34,8 +34,4 @@ class WarpModule @Inject constructor(
     override fun onEnable() {
         dynmapMarkerAdapter.enable()
     }
-
-    override fun onDisable() {
-        dynmapMarkerAdapter.disable()
-    }
 }

--- a/src/main/kotlin/com/projectcitybuild/features/warps/WarpModule.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/warps/WarpModule.kt
@@ -34,4 +34,8 @@ class WarpModule @Inject constructor(
     override fun onEnable() {
         dynmapMarkerAdapter.enable()
     }
+
+    override fun onDisable() {
+        dynmapMarkerAdapter.disable()
+    }
 }

--- a/src/main/kotlin/com/projectcitybuild/features/warps/adapters/dynmap/DynmapMarkerAdapter.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/warps/adapters/dynmap/DynmapMarkerAdapter.kt
@@ -1,16 +1,22 @@
 package com.projectcitybuild.features.warps.adapters.dynmap
 
+import com.projectcitybuild.core.SpigotListener
+import com.projectcitybuild.features.warps.events.WarpCreateEvent
+import com.projectcitybuild.features.warps.events.WarpDeleteEvent
 import com.projectcitybuild.features.warps.repositories.WarpRepository
 import com.projectcitybuild.modules.logger.PlatformLogger
+import dagger.Reusable
+import org.bukkit.event.EventHandler
 import org.bukkit.plugin.Plugin
 import org.dynmap.DynmapAPI
 import javax.inject.Inject
 
+@Reusable
 class DynmapMarkerAdapter @Inject constructor(
     private val plugin: Plugin,
     private val warpRepository: WarpRepository,
     private val logger: PlatformLogger,
-) {
+): SpigotListener {
     class DynmapNotFoundException: Exception("Dynmap plugin not found")
     class DynmapMarkerIconNotFoundException: Exception()
 
@@ -28,7 +34,12 @@ class DynmapMarkerAdapter @Inject constructor(
             logger.fatal("Found dynmap plugin but cannot access dynmap-api")
             throw DynmapNotFoundException()
         }
+
+        plugin.server.pluginManager.registerEvents(this, plugin)
     }
+
+    @EventHandler fun onWarpCreate(event: WarpCreateEvent) = updateWarpMarkers()
+    @EventHandler fun onWarpDelete(event: WarpDeleteEvent) = updateWarpMarkers()
 
     private fun updateWarpMarkers() {
         val markerAPI = dynmap.markerAPI

--- a/src/main/kotlin/com/projectcitybuild/features/warps/adapters/dynmap/DynmapMarkerAdapter.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/warps/adapters/dynmap/DynmapMarkerAdapter.kt
@@ -21,6 +21,7 @@ class DynmapMarkerAdapter @Inject constructor(
     class DynmapMarkerIconNotFoundException: Exception()
 
     private val markerSetName = "pcbridge"
+    private var isEnabled = false
 
     private lateinit var dynmap: DynmapAPI
 
@@ -35,13 +36,24 @@ class DynmapMarkerAdapter @Inject constructor(
             throw DynmapNotFoundException()
         }
 
+        isEnabled = true
+
         plugin.server.pluginManager.registerEvents(this, plugin)
+
+        updateWarpMarkers()
     }
 
     @EventHandler fun onWarpCreate(event: WarpCreateEvent) = updateWarpMarkers()
     @EventHandler fun onWarpDelete(event: WarpDeleteEvent) = updateWarpMarkers()
 
     private fun updateWarpMarkers() {
+        if (!isEnabled) {
+            logger.verbose("Dynmap integration disabled. Skipping warp marker update")
+            return
+        }
+
+        logger.verbose("Redrawing warp markers...")
+
         val markerAPI = dynmap.markerAPI
 
         val warpMarkerSet = markerAPI.getMarkerSet(markerSetName)

--- a/src/main/kotlin/com/projectcitybuild/features/warps/adapters/dynmap/DynmapMarkerAdapter.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/warps/adapters/dynmap/DynmapMarkerAdapter.kt
@@ -56,11 +56,12 @@ class DynmapMarkerAdapter @Inject constructor(
         logger.verbose("Redrawing warp markers...")
 
         val markerAPI = dynmap.markerAPI
+        val markerLabel = "Warps" // This name shows up in the Dynmap web interface
 
         val warpMarkerSet = markerAPI.getMarkerSet(markerSetName)
             ?: markerAPI.createMarkerSet(
                 markerSetName,
-                "warps",
+                markerLabel,
                 null, // TODO: what is this?
                 false, // TODO: what is this?
             )

--- a/src/main/kotlin/com/projectcitybuild/features/warps/adapters/dynmap/DynmapMarkerAdapter.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/warps/adapters/dynmap/DynmapMarkerAdapter.kt
@@ -26,19 +26,20 @@ class DynmapMarkerAdapter @Inject constructor(
     private lateinit var dynmap: DynmapAPI
 
     fun enable() {
-        val plugin = plugin.server.pluginManager.getPlugin("dynmap")
-        if (plugin == null) {
+        val anyPlugin = plugin.server.pluginManager.getPlugin("dynmap")
+        if (anyPlugin == null) {
             logger.warning("Cannot find dynmap pluigin")
             throw DynmapNotFoundException()
         }
-        if (plugin !is DynmapAPI) {
+        if (anyPlugin !is DynmapAPI) {
             logger.fatal("Found dynmap plugin but cannot access dynmap-api")
             throw DynmapNotFoundException()
         }
 
-        isEnabled = true
-
+        dynmap = anyPlugin
         plugin.server.pluginManager.registerEvents(this, plugin)
+
+        isEnabled = true
 
         updateWarpMarkers()
     }

--- a/src/main/kotlin/com/projectcitybuild/features/warps/adapters/dynmap/DynmapMarkerAdapter.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/warps/adapters/dynmap/DynmapMarkerAdapter.kt
@@ -1,0 +1,67 @@
+package com.projectcitybuild.features.warps.adapters.dynmap
+
+import com.projectcitybuild.features.warps.repositories.WarpRepository
+import com.projectcitybuild.modules.logger.PlatformLogger
+import org.bukkit.plugin.Plugin
+import org.dynmap.DynmapAPI
+import javax.inject.Inject
+
+class DynmapMarkerAdapter @Inject constructor(
+    private val plugin: Plugin,
+    private val warpRepository: WarpRepository,
+    private val logger: PlatformLogger,
+) {
+    class DynmapNotFoundException: Exception("Dynmap plugin not found")
+    class DynmapMarkerIconNotFoundException: Exception()
+
+    private val markerSetName = "pcbridge"
+
+    private lateinit var dynmap: DynmapAPI
+
+    fun enable() {
+        val plugin = plugin.server.pluginManager.getPlugin("dynmap")
+        if (plugin == null) {
+            logger.warning("Cannot find dynmap pluigin")
+            throw DynmapNotFoundException()
+        }
+        if (plugin !is DynmapAPI) {
+            logger.fatal("Found dynmap plugin but cannot access dynmap-api")
+            throw DynmapNotFoundException()
+        }
+    }
+
+    private fun updateWarpMarkers() {
+        val markerAPI = dynmap.markerAPI
+
+        val warpMarkerSet = markerAPI.getMarkerSet(markerSetName)
+            ?: markerAPI.createMarkerSet(
+                markerSetName,
+                "warps",
+                null, // TODO: what is this?
+                false, // TODO: what is this?
+            )
+
+        warpMarkerSet.layerPriority = 1
+        warpMarkerSet.hideByDefault = false
+
+        warpMarkerSet.markers.forEach {
+            it.deleteMarker()
+        }
+
+        val icon = markerAPI.getMarkerIcon("portal")
+            ?: throw DynmapMarkerIconNotFoundException()
+
+        warpRepository.all().forEach { warp ->
+            warpMarkerSet.createMarker(
+                "warp.${warp.name}",
+                warp.name,
+                warp.location.worldName,
+                warp.location.x,
+                warp.location.y,
+                warp.location.z,
+                icon,
+                false, // TODO: what is this?
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/projectcitybuild/features/warps/adapters/dynmap/DynmapMarkerAdapter.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/warps/adapters/dynmap/DynmapMarkerAdapter.kt
@@ -1,9 +1,11 @@
 package com.projectcitybuild.features.warps.adapters.dynmap
 
 import com.projectcitybuild.core.SpigotListener
+import com.projectcitybuild.entities.PluginConfig
 import com.projectcitybuild.features.warps.events.WarpCreateEvent
 import com.projectcitybuild.features.warps.events.WarpDeleteEvent
 import com.projectcitybuild.features.warps.repositories.WarpRepository
+import com.projectcitybuild.modules.config.PlatformConfig
 import com.projectcitybuild.modules.logger.PlatformLogger
 import dagger.Reusable
 import org.bukkit.event.EventHandler
@@ -15,6 +17,7 @@ import javax.inject.Inject
 class DynmapMarkerAdapter @Inject constructor(
     private val plugin: Plugin,
     private val warpRepository: WarpRepository,
+    private val config: PlatformConfig,
     private val logger: PlatformLogger,
 ): SpigotListener {
     class DynmapNotFoundException: Exception("Dynmap plugin not found")
@@ -73,7 +76,8 @@ class DynmapMarkerAdapter @Inject constructor(
             it.deleteMarker()
         }
 
-        val icon = markerAPI.getMarkerIcon("portal")
+        val iconName = config.get(PluginConfig.INTEGRATION_DYNMAP_WARP_ICON)
+        val icon = markerAPI.getMarkerIcon(iconName)
             ?: throw DynmapMarkerIconNotFoundException()
 
         warpRepository.all().forEach { warp ->

--- a/src/main/kotlin/com/projectcitybuild/features/warps/events/WarpCreateEvent.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/warps/events/WarpCreateEvent.kt
@@ -1,0 +1,20 @@
+package com.projectcitybuild.features.warps.events
+
+import org.bukkit.event.HandlerList
+import org.bukkit.event.Event as SpigotEvent
+
+class WarpCreateEvent: SpigotEvent() {
+
+    companion object {
+        private val HANDLERS = HandlerList()
+
+        @JvmStatic
+        fun getHandlerList(): HandlerList {
+            return HANDLERS
+        }
+    }
+
+    override fun getHandlers(): HandlerList {
+        return HANDLERS
+    }
+}

--- a/src/main/kotlin/com/projectcitybuild/features/warps/events/WarpDeleteEvent.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/warps/events/WarpDeleteEvent.kt
@@ -1,0 +1,20 @@
+package com.projectcitybuild.features.warps.events
+
+import org.bukkit.event.HandlerList
+import org.bukkit.event.Event as SpigotEvent
+
+class WarpDeleteEvent: SpigotEvent() {
+
+    companion object {
+        private val HANDLERS = HandlerList()
+
+        @JvmStatic
+        fun getHandlerList(): HandlerList {
+            return HANDLERS
+        }
+    }
+
+    override fun getHandlers(): HandlerList {
+        return HANDLERS
+    }
+}

--- a/src/main/kotlin/com/projectcitybuild/features/warps/repositories/WarpRepository.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/warps/repositories/WarpRepository.kt
@@ -56,6 +56,26 @@ class WarpRepository @Inject constructor(
             }
     }
 
+    fun all(): List<Warp> {
+        return dataSource.database()
+            .getResults("SELECT *` FROM `warps` ORDER BY `name` ASC")
+            .map { row ->
+                Warp(
+                    name = row.get("name"),
+                    location = CrossServerLocation(
+                        serverName = row.get("server_name"),
+                        worldName = row.get("world_name"),
+                        x = row.get("x"),
+                        y = row.get("y"),
+                        z = row.get("z"),
+                        pitch = row.get("pitch"),
+                        yaw = row.get("yaw"),
+                    ),
+                    createdAt = row.get("created_at"),
+                )
+            }
+    }
+
     fun add(warp: Warp) {
         dataSource.database().executeInsert(
             "INSERT INTO `warps` VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",

--- a/src/main/kotlin/com/projectcitybuild/features/warps/repositories/WarpRepository.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/warps/repositories/WarpRepository.kt
@@ -58,7 +58,7 @@ class WarpRepository @Inject constructor(
 
     fun all(): List<Warp> {
         return dataSource.database()
-            .getResults("SELECT *` FROM `warps` ORDER BY `name` ASC")
+            .getResults("SELECT * FROM `warps` ORDER BY `name` ASC")
             .map { row ->
                 Warp(
                     name = row.get("name"),

--- a/src/main/kotlin/com/projectcitybuild/features/warps/usecases/CreateWarpUseCase.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/warps/usecases/CreateWarpUseCase.kt
@@ -5,12 +5,15 @@ import com.projectcitybuild.core.utilities.Result
 import com.projectcitybuild.core.utilities.Success
 import com.projectcitybuild.entities.CrossServerLocation
 import com.projectcitybuild.entities.Warp
+import com.projectcitybuild.features.warps.events.WarpCreateEvent
 import com.projectcitybuild.features.warps.repositories.WarpRepository
 import com.projectcitybuild.modules.datetime.Time
+import com.projectcitybuild.modules.eventbroadcast.LocalEventBroadcaster
 import javax.inject.Inject
 
 class CreateWarpUseCase @Inject constructor(
     private val warpRepository: WarpRepository,
+    private val localEventBroadcaster: LocalEventBroadcaster,
     private val time: Time,
 ) {
     enum class FailureReason {
@@ -27,6 +30,8 @@ class CreateWarpUseCase @Inject constructor(
             time.now()
         )
         warpRepository.add(warp)
+
+        localEventBroadcaster.emit(WarpCreateEvent())
 
         return Success(Unit)
     }

--- a/src/main/kotlin/com/projectcitybuild/features/warps/usecases/DeleteWarpUseCase.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/warps/usecases/DeleteWarpUseCase.kt
@@ -3,11 +3,14 @@ package com.projectcitybuild.features.warps.usecases
 import com.projectcitybuild.core.utilities.Failure
 import com.projectcitybuild.core.utilities.Result
 import com.projectcitybuild.core.utilities.Success
+import com.projectcitybuild.features.warps.events.WarpDeleteEvent
 import com.projectcitybuild.features.warps.repositories.WarpRepository
+import com.projectcitybuild.modules.eventbroadcast.LocalEventBroadcaster
 import javax.inject.Inject
 
 class DeleteWarpUseCase @Inject constructor(
     private val warpRepository: WarpRepository,
+    private val localEventBroadcaster: LocalEventBroadcaster,
 ) {
     enum class FailureReason {
         WARP_NOT_FOUND,
@@ -19,6 +22,8 @@ class DeleteWarpUseCase @Inject constructor(
         }
         // TODO: Add confirmation
         warpRepository.delete(name)
+
+        localEventBroadcaster.emit(WarpDeleteEvent())
 
         return Success(Unit)
     }

--- a/src/main/kotlin/com/projectcitybuild/platforms/bungeecord/BungeecordComponent.kt
+++ b/src/main/kotlin/com/projectcitybuild/platforms/bungeecord/BungeecordComponent.kt
@@ -12,7 +12,7 @@ import com.projectcitybuild.modules.network.NetworkModule
 import com.projectcitybuild.modules.proxyadapter.BungeecordProxyAdapterModule
 import com.projectcitybuild.modules.scheduler.PlatformScheduler
 import com.projectcitybuild.modules.timer.PlatformTimer
-import com.projectcitybuild.platforms.bungeecord.BungeecordFeatureListModule.BungeecordFeatureModules
+import com.projectcitybuild.platforms.bungeecord.BungeecordModulesProvider.BungeecordFeatureModules
 import dagger.BindsInstance
 import dagger.Component
 import net.md_5.bungee.api.ProxyServer
@@ -24,7 +24,7 @@ import javax.inject.Singleton
     TimeProvider::class,
     ErrorReporterProvider::class,
     DateTimeFormatterProvider::class,
-    BungeecordFeatureListModule::class,
+    BungeecordModulesProvider::class,
     NetworkModule::class,
     DataSourceProvider::class,
     BungeecordProxyAdapterModule::class,

--- a/src/main/kotlin/com/projectcitybuild/platforms/bungeecord/BungeecordModulesProvider.kt
+++ b/src/main/kotlin/com/projectcitybuild/platforms/bungeecord/BungeecordModulesProvider.kt
@@ -3,17 +3,17 @@ package com.projectcitybuild.platforms.bungeecord
 import com.projectcitybuild.core.contracts.BungeecordFeatureModule
 import com.projectcitybuild.features.bans.BanModule
 import com.projectcitybuild.features.chat.ChatModule
-import com.projectcitybuild.features.utility.UtilityModule
 import com.projectcitybuild.features.joinmessage.JoinMessageModule
 import com.projectcitybuild.features.playercache.PlayerCacheModule
 import com.projectcitybuild.features.ranksync.RankSyncModule
 import com.projectcitybuild.features.teleporting.TeleportModule
+import com.projectcitybuild.features.utility.UtilityModule
 import dagger.Module
 import dagger.Provides
 import javax.inject.Qualifier
 
 @Module
-class BungeecordFeatureListModule {
+class BungeecordModulesProvider {
 
     @Qualifier
     @Retention(AnnotationRetention.BINARY)

--- a/src/main/kotlin/com/projectcitybuild/platforms/spigot/SpigotComponent.kt
+++ b/src/main/kotlin/com/projectcitybuild/platforms/spigot/SpigotComponent.kt
@@ -1,6 +1,5 @@
 package com.projectcitybuild.platforms.spigot
 
-import com.projectcitybuild.core.contracts.SpigotFeatureModule
 import com.projectcitybuild.modules.config.PlatformConfig
 import com.projectcitybuild.modules.database.DataSourceProvider
 import com.projectcitybuild.modules.datetime.TimeProvider
@@ -11,7 +10,6 @@ import com.projectcitybuild.modules.network.APIClient
 import com.projectcitybuild.modules.network.NetworkModule
 import com.projectcitybuild.modules.redis.RedisProvider
 import com.projectcitybuild.modules.scheduler.PlatformScheduler
-import com.projectcitybuild.platforms.spigot.SpigotFeatureListModule.SpigotFeatureModules
 import dagger.BindsInstance
 import dagger.Component
 import org.bukkit.plugin.Plugin
@@ -22,7 +20,6 @@ import javax.inject.Singleton
 @Component(modules = [
     TimeProvider::class,
     ErrorReporterProvider::class,
-    SpigotFeatureListModule::class,
     NetworkModule::class,
     DataSourceProvider::class,
     RedisProvider::class,
@@ -30,9 +27,6 @@ import javax.inject.Singleton
 interface SpigotComponent {
 
     fun container(): SpigotPlatform.Container
-
-    @SpigotFeatureModules
-    fun modules(): List<SpigotFeatureModule>
 
     @Component.Builder
     interface Builder {

--- a/src/main/kotlin/com/projectcitybuild/platforms/spigot/SpigotModulesContainer.kt
+++ b/src/main/kotlin/com/projectcitybuild/platforms/spigot/SpigotModulesContainer.kt
@@ -7,27 +7,17 @@ import com.projectcitybuild.features.joinmessage.JoinMessageModule
 import com.projectcitybuild.features.teleporthistory.TeleportHistoryModule
 import com.projectcitybuild.features.teleporting.TeleportModule
 import com.projectcitybuild.features.warps.WarpModule
-import dagger.Module
-import dagger.Provides
-import javax.inject.Qualifier
+import javax.inject.Inject
 
-@Module
-class SpigotFeatureListModule {
-
-    @Qualifier
-    @Retention(AnnotationRetention.BINARY)
-    annotation class SpigotFeatureModules
-
-    @Provides
-    @SpigotFeatureModules
-    fun modules(
-        chatModule: ChatModule.Spigot,
-        hubModule: HubModule,
-        joinMessageModule: JoinMessageModule.Spigot,
-        teleportModule: TeleportModule.Spigot,
-        teleportHistoryModule: TeleportHistoryModule.Spigot,
-        warpModule: WarpModule,
-    ): List<SpigotFeatureModule> = listOf(
+class SpigotModulesContainer @Inject constructor(
+    chatModule: ChatModule.Spigot,
+    hubModule: HubModule,
+    joinMessageModule: JoinMessageModule.Spigot,
+    teleportModule: TeleportModule.Spigot,
+    teleportHistoryModule: TeleportHistoryModule.Spigot,
+    warpModule: WarpModule,
+) {
+    val modules: List<SpigotFeatureModule> = listOf(
         chatModule,
         hubModule,
         joinMessageModule,

--- a/src/main/kotlin/com/projectcitybuild/platforms/spigot/SpigotPlatform.kt
+++ b/src/main/kotlin/com/projectcitybuild/platforms/spigot/SpigotPlatform.kt
@@ -38,6 +38,7 @@ class SpigotPlatform: JavaPlugin() {
                 PluginConfig.REDIS_PASSWORD,
                 PluginConfig.ERROR_REPORTING_SENTRY_ENABLED,
                 PluginConfig.ERROR_REPORTING_SENTRY_DSN,
+                PluginConfig.INTEGRATION_DYNMAP_WARP_ICON,
             )
         }
 

--- a/src/main/kotlin/com/projectcitybuild/platforms/spigot/SpigotPlatform.kt
+++ b/src/main/kotlin/com/projectcitybuild/platforms/spigot/SpigotPlatform.kt
@@ -86,6 +86,7 @@ class SpigotPlatform: JavaPlugin() {
                     module.spigotCommands.forEach { commandRegistry.register(it) }
                     module.spigotListeners.forEach { listenerRegistry.register(it) }
                     module.spigotSubChannelListeners.forEach { pluginMessageListener.register(it) }
+                    module.onEnable()
                 }
 
             }.onFailure {

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -3,6 +3,7 @@ name: PCBridge
 version: 3.6.0
 softdepend:
   - LuckPerms
+  - dynmap
 
 api-version: 1.16
 

--- a/src/test/com/projectcitybuild/features/warps/usecases/DeleteWarpUseCaseTest.kt
+++ b/src/test/com/projectcitybuild/features/warps/usecases/DeleteWarpUseCaseTest.kt
@@ -3,12 +3,14 @@ package com.projectcitybuild.features.warps.usecases
 import com.projectcitybuild.core.utilities.Failure
 import com.projectcitybuild.core.utilities.Success
 import com.projectcitybuild.features.warps.repositories.WarpRepository
+import com.projectcitybuild.modules.eventbroadcast.LocalEventBroadcaster
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
+import org.mockito.kotlin.any
 import org.powermock.api.mockito.PowerMockito.`when`
 import org.powermock.api.mockito.PowerMockito.mock
 
@@ -17,12 +19,14 @@ class DeleteWarpUseCaseTest {
     private lateinit var useCase: DeleteWarpUseCase
 
     private lateinit var warpRepository: WarpRepository
+    private lateinit var localEventBroadcaster: LocalEventBroadcaster
 
     @BeforeEach
     fun setUp() {
         warpRepository = mock(WarpRepository::class.java)
+        localEventBroadcaster = mock(LocalEventBroadcaster::class.java)
 
-        useCase = DeleteWarpUseCase(warpRepository)
+        useCase = DeleteWarpUseCase(warpRepository, localEventBroadcaster)
     }
 
     @Test
@@ -43,6 +47,17 @@ class DeleteWarpUseCaseTest {
         val result = useCase.deleteWarp(warpName)
 
         verify(warpRepository, times(1)).delete(warpName)
+        assertEquals(result, Success(Unit))
+    }
+
+    @Test
+    fun `should emit an event when a warp is deleted`() = runTest {
+        val warpName = "warp"
+        `when`(warpRepository.exists(warpName)).thenReturn(true)
+
+        val result = useCase.deleteWarp(warpName)
+
+        verify(localEventBroadcaster).emit(any())
         assertEquals(result, Success(Unit))
     }
 }


### PR DESCRIPTION
Integrates with dynmap to show a marker at the position of each warp.

Markers are redrawn when the plugin is enabled, and when warps are created and deleted