### PR TITLE
Move config keys into service classes

### DIFF
--- a/src/main/kotlin/com/projectcitybuild/modules/config/PlatformConfig.kt
+++ b/src/main/kotlin/com/projectcitybuild/modules/config/PlatformConfig.kt
@@ -3,9 +3,6 @@ package com.projectcitybuild.modules.config
 import com.projectcitybuild.entities.PluginConfig
 
 interface PlatformConfig {
-
-    fun load(vararg keys: PluginConfig.ConfigPath<*>)
-    
     fun <T> get(key: PluginConfig.ConfigPath<T>): T
     fun <T> set(key: PluginConfig.ConfigPath<T>, value: T)
 

--- a/src/main/kotlin/com/projectcitybuild/modules/config/implementations/BungeecordConfig.kt
+++ b/src/main/kotlin/com/projectcitybuild/modules/config/implementations/BungeecordConfig.kt
@@ -16,43 +16,73 @@ class BungeecordConfig(
     private val dataFolder: File
 ): PlatformConfig {
 
-    private var config: Configuration? = null
-    private fun getFile(): File = File(dataFolder, "config.yml")
+    private val file: File
+        get() = File(dataFolder, "config.yml")
+
+    private val config: Configuration by lazy {
+        createIfNeeded(file)
+
+        val config = ConfigurationProvider
+            .getProvider(YamlConfiguration::class.java)
+            .load(file)
+
+        generateDefaultConfig()
+
+        config
+    }
+
+    private fun generateDefaultConfig() {
+        arrayOf(
+            PluginConfig.API_KEY,
+            PluginConfig.API_BASE_URL,
+            PluginConfig.API_IS_LOGGING_ENABLED,
+            PluginConfig.WARPS_PER_PAGE,
+            PluginConfig.TP_REQUEST_AUTO_EXPIRE_SECONDS,
+            PluginConfig.DB_HOSTNAME,
+            PluginConfig.DB_PORT,
+            PluginConfig.DB_NAME,
+            PluginConfig.DB_USERNAME,
+            PluginConfig.DB_PASSWORD,
+            PluginConfig.ERROR_REPORTING_SENTRY_ENABLED,
+            PluginConfig.ERROR_REPORTING_SENTRY_DSN,
+            PluginConfig.GROUPS_APPEARANCE_ADMIN_DISPLAY_NAME,
+            PluginConfig.GROUPS_APPEARANCE_ADMIN_HOVER_NAME,
+            PluginConfig.GROUPS_APPEARANCE_SOP_DISPLAY_NAME,
+            PluginConfig.GROUPS_APPEARANCE_SOP_HOVER_NAME,
+            PluginConfig.GROUPS_APPEARANCE_OP_DISPLAY_NAME,
+            PluginConfig.GROUPS_APPEARANCE_OP_HOVER_NAME,
+            PluginConfig.GROUPS_APPEARANCE_MODERATOR_DISPLAY_NAME,
+            PluginConfig.GROUPS_APPEARANCE_MODERATOR_HOVER_NAME,
+            PluginConfig.GROUPS_APPEARANCE_TRUSTEDPLUS_HOVER_NAME,
+            PluginConfig.GROUPS_APPEARANCE_TRUSTED_HOVER_NAME,
+            PluginConfig.GROUPS_APPEARANCE_DONOR_HOVER_NAME,
+            PluginConfig.GROUPS_APPEARANCE_ARCHITECT_HOVER_NAME,
+            PluginConfig.GROUPS_APPEARANCE_ENGINEER_HOVER_NAME,
+            PluginConfig.GROUPS_APPEARANCE_PLANNER_HOVER_NAME,
+            PluginConfig.GROUPS_APPEARANCE_BUILDER_HOVER_NAME,
+            PluginConfig.GROUPS_APPEARANCE_INTERN_HOVER_NAME,
+        ).forEach { key ->
+            if (config.get(key.key) == null)
+                config.set(key.key, key.defaultValue)
+        }
+        save()
+    }
 
     @Suppress("UNCHECKED_CAST")
     override fun <T> get(key: PluginConfig.ConfigPath<T>): T {
-        val config = config ?: throw Exception("Attempted to read config file without loading it")
+        val config = config
         return config.get(key.key) as? T ?: key.defaultValue
     }
 
     override fun get(path: String): Any? {
-        val config = config ?: throw Exception("Attempted to read config file without loading it")
+        val config = config
         return config.get(path)
     }
 
     override fun <T> set(key: PluginConfig.ConfigPath<T>, value: T) {
-        val config = config ?: throw Exception("Attempted to read config file without loading it")
+        val config = config
 
         config.set(key.key, value)
-        save()
-    }
-
-    override fun load(vararg keys: PluginConfig.ConfigPath<*>) {
-        config = null
-
-        val file = getFile()
-        createIfNeeded(file)
-
-        config = ConfigurationProvider
-            .getProvider(YamlConfiguration::class.java)
-            .load(file)
-            .also { config ->
-                keys.forEach { key ->
-                    if (config.get(key.key) == null)
-                        config.set(key.key, key.defaultValue)
-                }
-            }
-
         save()
     }
 
@@ -72,9 +102,9 @@ class BungeecordConfig(
         }
     }
 
-    fun save() {
+    private fun save() {
         ConfigurationProvider
             .getProvider(YamlConfiguration::class.java)
-            .save(config, getFile())
+            .save(config, file)
     }
 }

--- a/src/main/kotlin/com/projectcitybuild/modules/config/implementations/SpigotConfig.kt
+++ b/src/main/kotlin/com/projectcitybuild/modules/config/implementations/SpigotConfig.kt
@@ -12,6 +12,32 @@ class SpigotConfig(
     private val config: FileConfiguration
 ): PlatformConfig {
 
+    init {
+        generateDefaultConfig()
+    }
+
+    private fun generateDefaultConfig() {
+        arrayOf(
+            PluginConfig.SPIGOT_SERVER_NAME,
+            PluginConfig.DB_HOSTNAME,
+            PluginConfig.DB_PORT,
+            PluginConfig.DB_NAME,
+            PluginConfig.DB_USERNAME,
+            PluginConfig.DB_PASSWORD,
+            PluginConfig.REDIS_HOSTNAME,
+            PluginConfig.REDIS_PORT,
+            PluginConfig.REDIS_USERNAME,
+            PluginConfig.REDIS_PASSWORD,
+            PluginConfig.ERROR_REPORTING_SENTRY_ENABLED,
+            PluginConfig.ERROR_REPORTING_SENTRY_DSN,
+            PluginConfig.INTEGRATION_DYNMAP_WARP_ICON,
+        ).forEach { key ->
+            config.addDefault(key.key, key.defaultValue)
+        }
+        config.options().copyDefaults(true)
+        plugin.saveConfig()
+    }
+
     override fun <T> get(key: PluginConfig.ConfigPath<T>): T {
         val value = config.get(key.key) as T
         if (value != null) {
@@ -20,19 +46,11 @@ class SpigotConfig(
         return key.defaultValue
     }
 
-    override fun <T> set(key: PluginConfig.ConfigPath<T>, value: T) {
-        return config.set(key.key, value)
-    }
-
     override fun get(path: String): Any? {
         return config.get(path)
     }
 
-    override fun load(vararg keys: PluginConfig.ConfigPath<*>) {
-        keys.forEach { key ->
-            config.addDefault(key.key, key.defaultValue)
-        }
-        config.options().copyDefaults(true)
-        plugin.saveConfig()
+    override fun <T> set(key: PluginConfig.ConfigPath<T>, value: T) {
+        return config.set(key.key, value)
     }
 }

--- a/src/main/kotlin/com/projectcitybuild/platforms/bungeecord/BungeecordPlatform.kt
+++ b/src/main/kotlin/com/projectcitybuild/platforms/bungeecord/BungeecordPlatform.kt
@@ -2,7 +2,6 @@ package com.projectcitybuild.platforms.bungeecord
 
 import com.projectcitybuild.core.contracts.BungeecordFeatureModule
 import com.projectcitybuild.entities.Channel
-import com.projectcitybuild.entities.PluginConfig
 import com.projectcitybuild.modules.channels.bungeecord.BungeecordMessageListener
 import com.projectcitybuild.modules.config.implementations.BungeecordConfig
 import com.projectcitybuild.modules.database.DataSource
@@ -25,43 +24,10 @@ class BungeecordPlatform: Plugin() {
     private lateinit var container: Container
 
     override fun onEnable() {
-        val config = BungeecordConfig(dataFolder).apply {
-            load(
-                PluginConfig.API_KEY,
-                PluginConfig.API_BASE_URL,
-                PluginConfig.API_IS_LOGGING_ENABLED,
-                PluginConfig.WARPS_PER_PAGE,
-                PluginConfig.TP_REQUEST_AUTO_EXPIRE_SECONDS,
-                PluginConfig.DB_HOSTNAME,
-                PluginConfig.DB_PORT,
-                PluginConfig.DB_NAME,
-                PluginConfig.DB_USERNAME,
-                PluginConfig.DB_PASSWORD,
-                PluginConfig.ERROR_REPORTING_SENTRY_ENABLED,
-                PluginConfig.ERROR_REPORTING_SENTRY_DSN,
-                PluginConfig.GROUPS_APPEARANCE_ADMIN_DISPLAY_NAME,
-                PluginConfig.GROUPS_APPEARANCE_ADMIN_HOVER_NAME,
-                PluginConfig.GROUPS_APPEARANCE_SOP_DISPLAY_NAME,
-                PluginConfig.GROUPS_APPEARANCE_SOP_HOVER_NAME,
-                PluginConfig.GROUPS_APPEARANCE_OP_DISPLAY_NAME,
-                PluginConfig.GROUPS_APPEARANCE_OP_HOVER_NAME,
-                PluginConfig.GROUPS_APPEARANCE_MODERATOR_DISPLAY_NAME,
-                PluginConfig.GROUPS_APPEARANCE_MODERATOR_HOVER_NAME,
-                PluginConfig.GROUPS_APPEARANCE_TRUSTEDPLUS_HOVER_NAME,
-                PluginConfig.GROUPS_APPEARANCE_TRUSTED_HOVER_NAME,
-                PluginConfig.GROUPS_APPEARANCE_DONOR_HOVER_NAME,
-                PluginConfig.GROUPS_APPEARANCE_ARCHITECT_HOVER_NAME,
-                PluginConfig.GROUPS_APPEARANCE_ENGINEER_HOVER_NAME,
-                PluginConfig.GROUPS_APPEARANCE_PLANNER_HOVER_NAME,
-                PluginConfig.GROUPS_APPEARANCE_BUILDER_HOVER_NAME,
-                PluginConfig.GROUPS_APPEARANCE_INTERN_HOVER_NAME,
-            )
-        }
-
         val component = DaggerBungeecordComponent.builder()
             .plugin(this)
             .proxyServer(proxy)
-            .config(config)
+            .config(BungeecordConfig(dataFolder))
             .logger(BungeecordLogger(logger))
             .scheduler(BungeecordScheduler(this))
             .timer(BungeecordTimer(this, proxy))

--- a/src/main/kotlin/com/projectcitybuild/platforms/spigot/SpigotPlatform.kt
+++ b/src/main/kotlin/com/projectcitybuild/platforms/spigot/SpigotPlatform.kt
@@ -24,29 +24,11 @@ class SpigotPlatform: JavaPlugin() {
     private lateinit var container: Container
 
     override fun onEnable() {
-        val config = SpigotConfig(plugin = this, config = config).apply {
-            load(
-                PluginConfig.SPIGOT_SERVER_NAME,
-                PluginConfig.DB_HOSTNAME,
-                PluginConfig.DB_PORT,
-                PluginConfig.DB_NAME,
-                PluginConfig.DB_USERNAME,
-                PluginConfig.DB_PASSWORD,
-                PluginConfig.REDIS_HOSTNAME,
-                PluginConfig.REDIS_PORT,
-                PluginConfig.REDIS_USERNAME,
-                PluginConfig.REDIS_PASSWORD,
-                PluginConfig.ERROR_REPORTING_SENTRY_ENABLED,
-                PluginConfig.ERROR_REPORTING_SENTRY_DSN,
-                PluginConfig.INTEGRATION_DYNMAP_WARP_ICON,
-            )
-        }
-
         val component = DaggerSpigotComponent.builder()
             .plugin(this)
             .javaPlugin(this)
-            .config(config)
-            .logger(SpigotLogger(logger = logger))
+            .config(SpigotConfig(this, config))
+            .logger(SpigotLogger(logger))
             .scheduler(SpigotScheduler(this))
             .localEventBroadcaster(SpigotLocalEventBroadcaster())
             .apiClient(APIClient { this.minecraftDispatcher })


### PR DESCRIPTION
Cleans up the platform classes by moving config key generation into each platform's config service