### PR TITLE
Switchable cache layer

### DIFF
--- a/src/main/kotlin/com/projectcitybuild/core/infrastructure/database/DataSource.kt
+++ b/src/main/kotlin/com/projectcitybuild/core/infrastructure/database/DataSource.kt
@@ -1,4 +1,4 @@
-package com.projectcitybuild.modules.database
+package com.projectcitybuild.core.infrastructure.database
 
 import co.aikar.idb.DatabaseOptions
 import co.aikar.idb.HikariPooledDatabase

--- a/src/main/kotlin/com/projectcitybuild/core/infrastructure/database/DataSourceProvider.kt
+++ b/src/main/kotlin/com/projectcitybuild/core/infrastructure/database/DataSourceProvider.kt
@@ -1,4 +1,4 @@
-package com.projectcitybuild.modules.database
+package com.projectcitybuild.core.infrastructure.database
 
 import com.projectcitybuild.entities.PluginConfig
 import com.projectcitybuild.modules.config.PlatformConfig

--- a/src/main/kotlin/com/projectcitybuild/core/infrastructure/database/DatabaseMigration.kt
+++ b/src/main/kotlin/com/projectcitybuild/core/infrastructure/database/DatabaseMigration.kt
@@ -1,4 +1,4 @@
-package com.projectcitybuild.modules.database
+package com.projectcitybuild.core.infrastructure.database
 
 import co.aikar.idb.HikariPooledDatabase
 

--- a/src/main/kotlin/com/projectcitybuild/core/infrastructure/database/Migration.kt
+++ b/src/main/kotlin/com/projectcitybuild/core/infrastructure/database/Migration.kt
@@ -1,4 +1,4 @@
-package com.projectcitybuild.modules.database
+package com.projectcitybuild.core.infrastructure.database
 
 import co.aikar.idb.HikariPooledDatabase
 import com.projectcitybuild.entities.migrations.*

--- a/src/main/kotlin/com/projectcitybuild/core/infrastructure/network/APIClient.kt
+++ b/src/main/kotlin/com/projectcitybuild/core/infrastructure/network/APIClient.kt
@@ -1,4 +1,4 @@
-package com.projectcitybuild.modules.network
+package com.projectcitybuild.core.infrastructure.network
 
 import com.projectcitybuild.entities.responses.ApiError
 

--- a/src/main/kotlin/com/projectcitybuild/core/infrastructure/network/APIClientImpl.kt
+++ b/src/main/kotlin/com/projectcitybuild/core/infrastructure/network/APIClientImpl.kt
@@ -1,4 +1,4 @@
-package com.projectcitybuild.modules.network
+package com.projectcitybuild.core.infrastructure.network
 
 import com.google.gson.Gson
 import com.projectcitybuild.entities.responses.ApiError

--- a/src/main/kotlin/com/projectcitybuild/core/infrastructure/network/APIClientMock.kt
+++ b/src/main/kotlin/com/projectcitybuild/core/infrastructure/network/APIClientMock.kt
@@ -1,4 +1,4 @@
-package com.projectcitybuild.modules.network
+package com.projectcitybuild.core.infrastructure.network
 
 import dagger.Reusable
 

--- a/src/main/kotlin/com/projectcitybuild/core/infrastructure/network/APIRequestFactory.kt
+++ b/src/main/kotlin/com/projectcitybuild/core/infrastructure/network/APIRequestFactory.kt
@@ -1,0 +1,9 @@
+package com.projectcitybuild.core.infrastructure.network
+
+import com.projectcitybuild.core.infrastructure.network.mojang.client.MojangClient
+import com.projectcitybuild.core.infrastructure.network.pcb.client.PCBClient
+
+class APIRequestFactory(
+    val pcb: PCBClient,
+    val mojang: MojangClient
+)

--- a/src/main/kotlin/com/projectcitybuild/core/infrastructure/network/NetworkProvider.kt
+++ b/src/main/kotlin/com/projectcitybuild/core/infrastructure/network/NetworkProvider.kt
@@ -1,9 +1,9 @@
-package com.projectcitybuild.modules.network
+package com.projectcitybuild.core.infrastructure.network
 
 import com.projectcitybuild.entities.PluginConfig
 import com.projectcitybuild.modules.config.PlatformConfig
-import com.projectcitybuild.modules.network.mojang.client.MojangClient
-import com.projectcitybuild.modules.network.pcb.client.PCBClient
+import com.projectcitybuild.core.infrastructure.network.mojang.client.MojangClient
+import com.projectcitybuild.core.infrastructure.network.pcb.client.PCBClient
 import dagger.Module
 import dagger.Provides
 

--- a/src/main/kotlin/com/projectcitybuild/core/infrastructure/network/mojang/client/MojangClient.kt
+++ b/src/main/kotlin/com/projectcitybuild/core/infrastructure/network/mojang/client/MojangClient.kt
@@ -1,6 +1,6 @@
-package com.projectcitybuild.modules.network.mojang.client
+package com.projectcitybuild.core.infrastructure.network.mojang.client
 
-import com.projectcitybuild.modules.network.mojang.requests.MojangApiInterface
+import com.projectcitybuild.core.infrastructure.network.mojang.requests.MojangApiInterface
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit

--- a/src/main/kotlin/com/projectcitybuild/core/infrastructure/network/mojang/requests/MojangApiInterface.kt
+++ b/src/main/kotlin/com/projectcitybuild/core/infrastructure/network/mojang/requests/MojangApiInterface.kt
@@ -1,4 +1,4 @@
-package com.projectcitybuild.modules.network.mojang.requests
+package com.projectcitybuild.core.infrastructure.network.mojang.requests
 
 import com.projectcitybuild.entities.responses.MojangPlayer
 import retrofit2.http.GET

--- a/src/main/kotlin/com/projectcitybuild/core/infrastructure/network/pcb/client/PCBClient.kt
+++ b/src/main/kotlin/com/projectcitybuild/core/infrastructure/network/pcb/client/PCBClient.kt
@@ -1,7 +1,7 @@
-package com.projectcitybuild.modules.network.pcb.client
+package com.projectcitybuild.core.infrastructure.network.pcb.client
 
-import com.projectcitybuild.modules.network.pcb.requests.AuthApiInterface
-import com.projectcitybuild.modules.network.pcb.requests.BanApiInterface
+import com.projectcitybuild.core.infrastructure.network.pcb.requests.AuthApiInterface
+import com.projectcitybuild.core.infrastructure.network.pcb.requests.BanApiInterface
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit

--- a/src/main/kotlin/com/projectcitybuild/core/infrastructure/network/pcb/requests/AuthApiInterface.kt
+++ b/src/main/kotlin/com/projectcitybuild/core/infrastructure/network/pcb/requests/AuthApiInterface.kt
@@ -1,4 +1,4 @@
-package com.projectcitybuild.modules.network.pcb.requests
+package com.projectcitybuild.core.infrastructure.network.pcb.requests
 
 import com.projectcitybuild.entities.responses.ApiResponse
 import com.projectcitybuild.entities.responses.AuthPlayerGroups

--- a/src/main/kotlin/com/projectcitybuild/core/infrastructure/network/pcb/requests/BanApiInterface.kt
+++ b/src/main/kotlin/com/projectcitybuild/core/infrastructure/network/pcb/requests/BanApiInterface.kt
@@ -1,4 +1,4 @@
-package com.projectcitybuild.modules.network.pcb.requests
+package com.projectcitybuild.core.infrastructure.network.pcb.requests
 
 import com.projectcitybuild.entities.responses.ApiResponse
 import com.projectcitybuild.entities.responses.GameBan

--- a/src/main/kotlin/com/projectcitybuild/core/infrastructure/redis/RedisConnection.kt
+++ b/src/main/kotlin/com/projectcitybuild/core/infrastructure/redis/RedisConnection.kt
@@ -1,4 +1,4 @@
-package com.projectcitybuild.modules.redis
+package com.projectcitybuild.core.infrastructure.redis
 
 import redis.clients.jedis.Jedis
 import redis.clients.jedis.JedisPool

--- a/src/main/kotlin/com/projectcitybuild/core/infrastructure/redis/RedisProvider.kt
+++ b/src/main/kotlin/com/projectcitybuild/core/infrastructure/redis/RedisProvider.kt
@@ -1,4 +1,4 @@
-package com.projectcitybuild.modules.redis
+package com.projectcitybuild.core.infrastructure.redis
 
 import com.projectcitybuild.entities.PluginConfig
 import com.projectcitybuild.modules.config.PlatformConfig

--- a/src/main/kotlin/com/projectcitybuild/entities/PluginConfig.kt
+++ b/src/main/kotlin/com/projectcitybuild/entities/PluginConfig.kt
@@ -27,6 +27,10 @@ sealed class PluginConfig {
         val ERROR_REPORTING_SENTRY_ENABLED = "error_reporting.sentry.enabled" defaultTo false
         val ERROR_REPORTING_SENTRY_DSN = "error_reporting.sentry.dsn" defaultTo "https://<key>@sentry.io/<project>"
 
+        // Supports 'redis' or 'flatfile'
+        val SHARED_CACHE_ADAPTER = "shared_cache.adapter" defaultTo "flatfile"
+        val SHARED_CACHE_FILE_RELATIVE_PATH = "shared_cache.flatfile.relative_path" defaultTo "../../cache/pcbridge"
+
         val WARPS_PER_PAGE = "warps.warps_per_page" defaultTo 15
 
         val TP_REQUEST_AUTO_EXPIRE_SECONDS = "teleports.requests.auto_expiry_in_seconds" defaultTo 20

--- a/src/main/kotlin/com/projectcitybuild/entities/migrations/20220114_first_time_run.kt
+++ b/src/main/kotlin/com/projectcitybuild/entities/migrations/20220114_first_time_run.kt
@@ -1,7 +1,7 @@
 package com.projectcitybuild.entities.migrations
 
 import co.aikar.idb.HikariPooledDatabase
-import com.projectcitybuild.modules.database.DatabaseMigration
+import com.projectcitybuild.core.infrastructure.database.DatabaseMigration
 
 class `20220114_first_time_run`: DatabaseMigration {
     override val description = "First-time run"

--- a/src/main/kotlin/com/projectcitybuild/entities/migrations/20220115_player_configs_warps.kt
+++ b/src/main/kotlin/com/projectcitybuild/entities/migrations/20220115_player_configs_warps.kt
@@ -1,7 +1,7 @@
 package com.projectcitybuild.entities.migrations
 
 import co.aikar.idb.HikariPooledDatabase
-import com.projectcitybuild.modules.database.DatabaseMigration
+import com.projectcitybuild.core.infrastructure.database.DatabaseMigration
 
 class `20220115_player_configs_warps`: DatabaseMigration {
     override val description = "Add player configs and warps"

--- a/src/main/kotlin/com/projectcitybuild/entities/migrations/20220120_teleport_history.kt
+++ b/src/main/kotlin/com/projectcitybuild/entities/migrations/20220120_teleport_history.kt
@@ -1,7 +1,7 @@
 package com.projectcitybuild.entities.migrations
 
 import co.aikar.idb.HikariPooledDatabase
-import com.projectcitybuild.modules.database.DatabaseMigration
+import com.projectcitybuild.core.infrastructure.database.DatabaseMigration
 
 class `20220120_teleport_history`: DatabaseMigration {
     override val description = "Add last_known_locations"

--- a/src/main/kotlin/com/projectcitybuild/entities/migrations/20220201_add_hub.kt
+++ b/src/main/kotlin/com/projectcitybuild/entities/migrations/20220201_add_hub.kt
@@ -1,7 +1,7 @@
 package com.projectcitybuild.entities.migrations
 
 import co.aikar.idb.HikariPooledDatabase
-import com.projectcitybuild.modules.database.DatabaseMigration
+import com.projectcitybuild.core.infrastructure.database.DatabaseMigration
 
 class `20220201_add_hub`: DatabaseMigration {
     override val description = "Add hub location"

--- a/src/main/kotlin/com/projectcitybuild/entities/migrations/20220201_add_ip_bans.kt
+++ b/src/main/kotlin/com/projectcitybuild/entities/migrations/20220201_add_ip_bans.kt
@@ -1,7 +1,7 @@
 package com.projectcitybuild.entities.migrations
 
 import co.aikar.idb.HikariPooledDatabase
-import com.projectcitybuild.modules.database.DatabaseMigration
+import com.projectcitybuild.core.infrastructure.database.DatabaseMigration
 
 class `20220201_add_ip_bans`: DatabaseMigration {
     override val description = "Add IP bans table"

--- a/src/main/kotlin/com/projectcitybuild/entities/migrations/20220207_add_teleport_message_silencing.kt
+++ b/src/main/kotlin/com/projectcitybuild/entities/migrations/20220207_add_teleport_message_silencing.kt
@@ -1,7 +1,7 @@
 package com.projectcitybuild.entities.migrations
 
 import co.aikar.idb.HikariPooledDatabase
-import com.projectcitybuild.modules.database.DatabaseMigration
+import com.projectcitybuild.core.infrastructure.database.DatabaseMigration
 
 class `20220207_add_teleport_message_silencing`: DatabaseMigration {
     override val description = "Add a column to silence teleport messages"

--- a/src/main/kotlin/com/projectcitybuild/features/bans/repositories/BanRepository.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/bans/repositories/BanRepository.kt
@@ -1,8 +1,8 @@
 package com.projectcitybuild.features.bans.repositories
 
 import com.projectcitybuild.entities.responses.GameBan
-import com.projectcitybuild.modules.network.APIClient
-import com.projectcitybuild.modules.network.APIRequestFactory
+import com.projectcitybuild.core.infrastructure.network.APIClient
+import com.projectcitybuild.core.infrastructure.network.APIRequestFactory
 import java.util.*
 import javax.inject.Inject
 

--- a/src/main/kotlin/com/projectcitybuild/features/bans/repositories/IPBanRepository.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/bans/repositories/IPBanRepository.kt
@@ -1,7 +1,7 @@
 package com.projectcitybuild.features.bans.repositories
 
 import com.projectcitybuild.entities.IPBan
-import com.projectcitybuild.modules.database.DataSource
+import com.projectcitybuild.core.infrastructure.database.DataSource
 import javax.inject.Inject
 
 class IPBanRepository @Inject constructor(

--- a/src/main/kotlin/com/projectcitybuild/features/chat/repositories/ChatIgnoreRepository.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/chat/repositories/ChatIgnoreRepository.kt
@@ -1,6 +1,6 @@
 package com.projectcitybuild.features.chat.repositories
 
-import com.projectcitybuild.modules.database.DataSource
+import com.projectcitybuild.core.infrastructure.database.DataSource
 import java.sql.Date
 import javax.inject.Inject
 

--- a/src/main/kotlin/com/projectcitybuild/features/hub/repositories/HubRepository.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/hub/repositories/HubRepository.kt
@@ -1,7 +1,7 @@
 package com.projectcitybuild.features.hub.repositories
 
 import com.projectcitybuild.entities.CrossServerLocation
-import com.projectcitybuild.modules.database.DataSource
+import com.projectcitybuild.core.infrastructure.database.DataSource
 import com.projectcitybuild.modules.datetime.time.Time
 import javax.inject.Inject
 

--- a/src/main/kotlin/com/projectcitybuild/features/ranksync/usecases/GenerateAccountVerificationURLUseCase.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/ranksync/usecases/GenerateAccountVerificationURLUseCase.kt
@@ -3,8 +3,8 @@ package com.projectcitybuild.features.ranksync.usecases
 import com.projectcitybuild.core.utilities.Failure
 import com.projectcitybuild.core.utilities.Result
 import com.projectcitybuild.core.utilities.Success
-import com.projectcitybuild.modules.network.APIClient
-import com.projectcitybuild.modules.network.APIRequestFactory
+import com.projectcitybuild.core.infrastructure.network.APIClient
+import com.projectcitybuild.core.infrastructure.network.APIRequestFactory
 import java.util.*
 import javax.inject.Inject
 

--- a/src/main/kotlin/com/projectcitybuild/features/ranksync/usecases/UpdatePlayerGroupsUseCase.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/ranksync/usecases/UpdatePlayerGroupsUseCase.kt
@@ -6,8 +6,8 @@ import com.projectcitybuild.core.utilities.Success
 import com.projectcitybuild.entities.PluginConfig
 import com.projectcitybuild.entities.responses.Group
 import com.projectcitybuild.modules.config.PlatformConfig
-import com.projectcitybuild.modules.network.APIClient
-import com.projectcitybuild.modules.network.APIRequestFactory
+import com.projectcitybuild.core.infrastructure.network.APIClient
+import com.projectcitybuild.core.infrastructure.network.APIRequestFactory
 import com.projectcitybuild.modules.permissions.Permissions
 import java.util.*
 import javax.inject.Inject

--- a/src/main/kotlin/com/projectcitybuild/features/teleporthistory/repositories/LastKnownLocationRepositoy.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/teleporthistory/repositories/LastKnownLocationRepositoy.kt
@@ -2,7 +2,7 @@ package com.projectcitybuild.features.teleporthistory.repositories
 
 import com.projectcitybuild.entities.CrossServerLocation
 import com.projectcitybuild.entities.LastKnownLocation
-import com.projectcitybuild.modules.database.DataSource
+import com.projectcitybuild.core.infrastructure.database.DataSource
 import java.time.LocalDateTime
 import java.util.*
 import javax.inject.Inject

--- a/src/main/kotlin/com/projectcitybuild/features/teleporting/repositories/QueuedTeleportRepository.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/teleporting/repositories/QueuedTeleportRepository.kt
@@ -2,7 +2,7 @@ package com.projectcitybuild.features.teleporting.repositories
 
 import com.projectcitybuild.entities.QueuedTeleport
 import com.projectcitybuild.entities.TeleportType
-import com.projectcitybuild.modules.database.DataSource
+import com.projectcitybuild.core.infrastructure.database.DataSource
 import java.util.*
 import javax.inject.Inject
 

--- a/src/main/kotlin/com/projectcitybuild/features/utility/commands/PCBridgeCommand.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/utility/commands/PCBridgeCommand.kt
@@ -4,7 +4,7 @@ import com.projectcitybuild.core.InvalidCommandArgumentsException
 import com.projectcitybuild.core.Regex
 import com.projectcitybuild.entities.IPBan
 import com.projectcitybuild.features.bans.repositories.IPBanRepository
-import com.projectcitybuild.modules.database.DataSource
+import com.projectcitybuild.core.infrastructure.database.DataSource
 import com.projectcitybuild.modules.logger.PlatformLogger
 import com.projectcitybuild.modules.textcomponentbuilder.send
 import com.projectcitybuild.platforms.bungeecord.environment.BungeecordCommand

--- a/src/main/kotlin/com/projectcitybuild/features/warps/repositories/QueuedWarpRepository.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/warps/repositories/QueuedWarpRepository.kt
@@ -2,7 +2,7 @@ package com.projectcitybuild.features.warps.repositories
 
 import com.projectcitybuild.entities.CrossServerLocation
 import com.projectcitybuild.entities.Warp
-import com.projectcitybuild.modules.database.DataSource
+import com.projectcitybuild.core.infrastructure.database.DataSource
 import java.util.*
 import javax.inject.Inject
 

--- a/src/main/kotlin/com/projectcitybuild/features/warps/repositories/WarpRepository.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/warps/repositories/WarpRepository.kt
@@ -2,8 +2,8 @@ package com.projectcitybuild.features.warps.repositories
 
 import com.projectcitybuild.entities.CrossServerLocation
 import com.projectcitybuild.entities.Warp
-import com.projectcitybuild.modules.database.DataSource
-import com.projectcitybuild.modules.redis.RedisConnection
+import com.projectcitybuild.core.infrastructure.database.DataSource
+import com.projectcitybuild.core.infrastructure.redis.RedisConnection
 import dagger.Reusable
 import javax.inject.Inject
 

--- a/src/main/kotlin/com/projectcitybuild/modules/config/implementations/SpigotConfig.kt
+++ b/src/main/kotlin/com/projectcitybuild/modules/config/implementations/SpigotConfig.kt
@@ -30,6 +30,8 @@ class SpigotConfig(
             PluginConfig.REDIS_PASSWORD,
             PluginConfig.ERROR_REPORTING_SENTRY_ENABLED,
             PluginConfig.ERROR_REPORTING_SENTRY_DSN,
+            PluginConfig.SHARED_CACHE_ADAPTER,
+            PluginConfig.SHARED_CACHE_FILE_RELATIVE_PATH,
             PluginConfig.INTEGRATION_DYNMAP_WARP_ICON,
         ).forEach { key ->
             config.addDefault(key.key, key.defaultValue)

--- a/src/main/kotlin/com/projectcitybuild/modules/network/APIRequestFactory.kt
+++ b/src/main/kotlin/com/projectcitybuild/modules/network/APIRequestFactory.kt
@@ -1,9 +1,0 @@
-package com.projectcitybuild.modules.network
-
-import com.projectcitybuild.modules.network.mojang.client.MojangClient
-import com.projectcitybuild.modules.network.pcb.client.PCBClient
-
-class APIRequestFactory(
-    val pcb: PCBClient,
-    val mojang: MojangClient
-)

--- a/src/main/kotlin/com/projectcitybuild/modules/playerconfig/PlayerConfigRepository.kt
+++ b/src/main/kotlin/com/projectcitybuild/modules/playerconfig/PlayerConfigRepository.kt
@@ -1,7 +1,7 @@
 package com.projectcitybuild.modules.playerconfig
 
 import com.projectcitybuild.entities.PlayerConfig
-import com.projectcitybuild.modules.database.DataSource
+import com.projectcitybuild.core.infrastructure.database.DataSource
 import java.time.LocalDateTime
 import java.util.*
 import javax.inject.Inject

--- a/src/main/kotlin/com/projectcitybuild/modules/playeruuid/PlayerUUIDRepository.kt
+++ b/src/main/kotlin/com/projectcitybuild/modules/playeruuid/PlayerUUIDRepository.kt
@@ -2,8 +2,8 @@ package com.projectcitybuild.modules.playeruuid
 
 import com.projectcitybuild.core.extensions.toDashFormattedUUID
 import com.projectcitybuild.entities.responses.MojangPlayer
-import com.projectcitybuild.modules.network.APIClient
-import com.projectcitybuild.modules.network.APIRequestFactory
+import com.projectcitybuild.core.infrastructure.network.APIClient
+import com.projectcitybuild.core.infrastructure.network.APIRequestFactory
 import com.projectcitybuild.modules.proxyadapter.playerlist.OnlinePlayerList
 import java.util.*
 import javax.inject.Inject

--- a/src/main/kotlin/com/projectcitybuild/modules/sharedcache/SharedCache.kt
+++ b/src/main/kotlin/com/projectcitybuild/modules/sharedcache/SharedCache.kt
@@ -1,0 +1,5 @@
+package com.projectcitybuild.modules.sharedcache
+
+interface SharedCache {
+
+}

--- a/src/main/kotlin/com/projectcitybuild/modules/sharedcache/SharedCache.kt
+++ b/src/main/kotlin/com/projectcitybuild/modules/sharedcache/SharedCache.kt
@@ -1,5 +1,0 @@
-package com.projectcitybuild.modules.sharedcache
-
-interface SharedCache {
-
-}

--- a/src/main/kotlin/com/projectcitybuild/modules/sharedcache/SharedCacheSet.kt
+++ b/src/main/kotlin/com/projectcitybuild/modules/sharedcache/SharedCacheSet.kt
@@ -1,7 +1,7 @@
 package com.projectcitybuild.modules.sharedcache
 
 /**
- * Represents a cache that is shared between all servers.
+ * Represents a cachable String Set that is shared between all servers.
  *
  * Anything that conforms to this interface must guarantee that
  * regardless of which server it's used from, the underlying

--- a/src/main/kotlin/com/projectcitybuild/modules/sharedcache/SharedCacheSet.kt
+++ b/src/main/kotlin/com/projectcitybuild/modules/sharedcache/SharedCacheSet.kt
@@ -1,0 +1,20 @@
+package com.projectcitybuild.modules.sharedcache
+
+/**
+ * Represents a cache that is shared between all servers.
+ *
+ * Anything that conforms to this interface must guarantee that
+ * regardless of which server it's used from, the underlying
+ * data will be synchronised.
+ */
+interface SharedCacheSet {
+    var key: String
+
+    fun has(value: String): Boolean
+    fun add(value: String)
+    fun add(values: List<String>)
+    fun remove(value: String)
+    fun removeAll()
+    fun all(): Set<String>
+}
+

--- a/src/main/kotlin/com/projectcitybuild/modules/sharedcache/SharedCacheSetFactory.kt
+++ b/src/main/kotlin/com/projectcitybuild/modules/sharedcache/SharedCacheSetFactory.kt
@@ -1,0 +1,11 @@
+package com.projectcitybuild.modules.sharedcache
+
+import javax.inject.Inject
+
+class SharedCacheSetFactory @Inject constructor(
+    private val adapter: SharedCacheSet
+) {
+    fun build(key: String): SharedCacheSet {
+        return adapter.also { it.key = "pcbridge:$key" }
+    }
+}

--- a/src/main/kotlin/com/projectcitybuild/modules/sharedcache/SharedCacheSetProvider.kt
+++ b/src/main/kotlin/com/projectcitybuild/modules/sharedcache/SharedCacheSetProvider.kt
@@ -1,0 +1,27 @@
+package com.projectcitybuild.modules.sharedcache
+
+import com.projectcitybuild.entities.PluginConfig
+import com.projectcitybuild.modules.config.PlatformConfig
+import com.projectcitybuild.modules.sharedcache.adapters.FlatFileSharedCacheSet
+import com.projectcitybuild.modules.sharedcache.adapters.RedisSharedCacheSet
+import dagger.Module
+import dagger.Provides
+
+@Module
+class SharedCacheSetProvider {
+
+    @Provides
+    fun provideSharedCacheSet(
+        config: PlatformConfig,
+        redisSharedCacheSet: RedisSharedCacheSet,
+        flatFileSharedCacheSet: FlatFileSharedCacheSet,
+    ): SharedCacheSet {
+        val adapter = config.get(PluginConfig.SHARED_CACHE_ADAPTER)
+
+        return when (adapter) {
+            "redis" -> redisSharedCacheSet
+            "flatfile" -> flatFileSharedCacheSet
+            else -> throw Exception("$adapter is not a valid Shared Cache adapter. Must be of [redis, flatfile]")
+        }
+    }
+}

--- a/src/main/kotlin/com/projectcitybuild/modules/sharedcache/adapters/FlatFileSharedCacheSet.kt
+++ b/src/main/kotlin/com/projectcitybuild/modules/sharedcache/adapters/FlatFileSharedCacheSet.kt
@@ -1,0 +1,35 @@
+package com.projectcitybuild.modules.sharedcache.adapters
+
+import com.projectcitybuild.modules.sharedcache.SharedCacheSet
+import javax.inject.Inject
+
+class FlatFileSharedCacheSet @Inject constructor(): SharedCacheSet {
+
+    override lateinit var key: String
+
+    private val fileName = key.replace(oldValue = ":", newValue = ".")
+
+    override fun has(value: String): Boolean {
+        TODO()
+    }
+
+    override fun add(value: String) {
+        TODO()
+    }
+
+    override fun add(values: List<String>) {
+        TODO()
+    }
+
+    override fun remove(value: String) {
+        TODO()
+    }
+
+    override fun removeAll() {
+        TODO()
+    }
+
+    override fun all(): Set<String> {
+        TODO()
+    }
+}

--- a/src/main/kotlin/com/projectcitybuild/modules/sharedcache/adapters/FlatFileSharedCacheSet.kt
+++ b/src/main/kotlin/com/projectcitybuild/modules/sharedcache/adapters/FlatFileSharedCacheSet.kt
@@ -3,7 +3,12 @@ package com.projectcitybuild.modules.sharedcache.adapters
 import com.projectcitybuild.entities.PluginConfig
 import com.projectcitybuild.modules.config.PlatformConfig
 import com.projectcitybuild.modules.sharedcache.SharedCacheSet
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
+import kotlinx.serialization.json.*
 import java.io.File
+import java.io.FileWriter
+import java.nio.charset.Charset
 import javax.inject.Inject
 
 class FlatFileSharedCacheSet @Inject constructor(
@@ -17,6 +22,9 @@ class FlatFileSharedCacheSet @Inject constructor(
     private val fileRelativePath = config.get(PluginConfig.SHARED_CACHE_FILE_RELATIVE_PATH) + "/" + fileName
     private val file = baseFolder.resolve(fileRelativePath)
 
+    @Serializable
+    data class Data(val set: Set<String>)
+
     private fun createFileIfNeeded() {
         if (!file.exists()) {
             file.mkdirs()
@@ -24,39 +32,49 @@ class FlatFileSharedCacheSet @Inject constructor(
         }
     }
 
+    private fun write(writeOperation: (MutableSet<String>) -> Unit) {
+        createFileIfNeeded()
+
+        val data = Json.decodeFromString<Data>(file.readText())
+        val mutatedSet = data.set.toMutableSet().also(writeOperation)
+        val json = Json.encodeToJsonElement(Data(mutatedSet))
+
+        FileWriter(file, Charset.defaultCharset()).use {
+            it.write(json.toString())
+        }
+    }
+
+    private fun readSet(): Set<String> {
+        val fileContents = file.readText()
+        val data = Json.decodeFromString<Data>(fileContents)
+        return data.set
+    }
+
     override fun has(value: String): Boolean {
         if (!file.exists()) return false
 
-        TODO()
+        return readSet().contains(value)
     }
 
     override fun add(value: String) {
-        createFileIfNeeded()
-
-        TODO()
+        write { it.add(value) }
     }
 
     override fun add(values: List<String>) {
-        createFileIfNeeded()
-
-        TODO()
+        write { it.addAll(values) }
     }
 
     override fun remove(value: String) {
-        createFileIfNeeded()
-
-        TODO()
+        write { it.remove(value) }
     }
 
     override fun removeAll() {
-        createFileIfNeeded()
-
-        TODO()
+        write { it.clear() }
     }
 
     override fun all(): Set<String> {
         if (!file.exists()) return emptySet()
 
-        TODO()
+        return readSet()
     }
 }

--- a/src/main/kotlin/com/projectcitybuild/modules/sharedcache/adapters/FlatFileSharedCacheSet.kt
+++ b/src/main/kotlin/com/projectcitybuild/modules/sharedcache/adapters/FlatFileSharedCacheSet.kt
@@ -38,6 +38,12 @@ class FlatFileSharedCacheSet @Inject constructor(
         }
         if (!file.exists()) {
             file.createNewFile()
+
+            val json = Json.encodeToJsonElement(Data(emptySet()))
+
+            FileWriter(file, Charset.defaultCharset()).use {
+                it.write(json.toString())
+            }
         }
     }
 

--- a/src/main/kotlin/com/projectcitybuild/modules/sharedcache/adapters/FlatFileSharedCacheSet.kt
+++ b/src/main/kotlin/com/projectcitybuild/modules/sharedcache/adapters/FlatFileSharedCacheSet.kt
@@ -4,23 +4,26 @@ import com.projectcitybuild.entities.PluginConfig
 import com.projectcitybuild.modules.config.PlatformConfig
 import com.projectcitybuild.modules.sharedcache.SharedCacheSet
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.*
-import kotlinx.serialization.json.*
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.encodeToJsonElement
 import java.io.File
 import java.io.FileWriter
 import java.nio.charset.Charset
 import javax.inject.Inject
 
 class FlatFileSharedCacheSet @Inject constructor(
-    config: PlatformConfig,
-    baseFolder: File,
+    private val config: PlatformConfig,
+    private val baseFolder: File,
 ): SharedCacheSet {
 
     override lateinit var key: String
 
-    private val fileName = key.replace(oldValue = ":", newValue = ".")
-    private val fileRelativePath = config.get(PluginConfig.SHARED_CACHE_FILE_RELATIVE_PATH) + "/" + fileName
-    private val file = baseFolder.resolve(fileRelativePath)
+    private val file by lazy {
+        val fileName = key.replace(oldValue = ":", newValue = ".")
+        val fileRelativePath = config.get(PluginConfig.SHARED_CACHE_FILE_RELATIVE_PATH) + "/" + fileName
+        baseFolder.resolve(fileRelativePath)
+    }
 
     @Serializable
     data class Data(val set: Set<String>)

--- a/src/main/kotlin/com/projectcitybuild/modules/sharedcache/adapters/FlatFileSharedCacheSet.kt
+++ b/src/main/kotlin/com/projectcitybuild/modules/sharedcache/adapters/FlatFileSharedCacheSet.kt
@@ -1,35 +1,62 @@
 package com.projectcitybuild.modules.sharedcache.adapters
 
+import com.projectcitybuild.entities.PluginConfig
+import com.projectcitybuild.modules.config.PlatformConfig
 import com.projectcitybuild.modules.sharedcache.SharedCacheSet
+import java.io.File
 import javax.inject.Inject
 
-class FlatFileSharedCacheSet @Inject constructor(): SharedCacheSet {
+class FlatFileSharedCacheSet @Inject constructor(
+    config: PlatformConfig,
+    baseFolder: File,
+): SharedCacheSet {
 
     override lateinit var key: String
 
     private val fileName = key.replace(oldValue = ":", newValue = ".")
+    private val fileRelativePath = config.get(PluginConfig.SHARED_CACHE_FILE_RELATIVE_PATH) + "/" + fileName
+    private val file = baseFolder.resolve(fileRelativePath)
+
+    private fun createFileIfNeeded() {
+        if (!file.exists()) {
+            file.mkdirs()
+            file.createNewFile()
+        }
+    }
 
     override fun has(value: String): Boolean {
+        if (!file.exists()) return false
+
         TODO()
     }
 
     override fun add(value: String) {
+        createFileIfNeeded()
+
         TODO()
     }
 
     override fun add(values: List<String>) {
+        createFileIfNeeded()
+
         TODO()
     }
 
     override fun remove(value: String) {
+        createFileIfNeeded()
+
         TODO()
     }
 
     override fun removeAll() {
+        createFileIfNeeded()
+
         TODO()
     }
 
     override fun all(): Set<String> {
+        if (!file.exists()) return emptySet()
+
         TODO()
     }
 }

--- a/src/main/kotlin/com/projectcitybuild/modules/sharedcache/adapters/FlatFileSharedCacheSet.kt
+++ b/src/main/kotlin/com/projectcitybuild/modules/sharedcache/adapters/FlatFileSharedCacheSet.kt
@@ -19,18 +19,24 @@ class FlatFileSharedCacheSet @Inject constructor(
 
     override lateinit var key: String
 
+    private val folder by lazy {
+        val relativePath = config.get(PluginConfig.SHARED_CACHE_FILE_RELATIVE_PATH)
+        baseFolder.resolve(relativePath)
+    }
+
     private val file by lazy {
-        val fileName = key.replace(oldValue = ":", newValue = ".")
-        val fileRelativePath = config.get(PluginConfig.SHARED_CACHE_FILE_RELATIVE_PATH) + "/" + fileName
-        baseFolder.resolve(fileRelativePath)
+        val fileName = key.replace(oldValue = ":", newValue = ".") + ".json"
+        File(folder, fileName)
     }
 
     @Serializable
     data class Data(val set: Set<String>)
 
     private fun createFileIfNeeded() {
+        if (!folder.exists()) {
+            folder.mkdirs()
+        }
         if (!file.exists()) {
-            file.mkdirs()
             file.createNewFile()
         }
     }

--- a/src/main/kotlin/com/projectcitybuild/modules/sharedcache/adapters/RedisSharedCacheSet.kt
+++ b/src/main/kotlin/com/projectcitybuild/modules/sharedcache/adapters/RedisSharedCacheSet.kt
@@ -1,0 +1,48 @@
+package com.projectcitybuild.modules.sharedcache.adapters
+
+import com.projectcitybuild.core.infrastructure.redis.RedisConnection
+import com.projectcitybuild.modules.sharedcache.SharedCacheSet
+import javax.inject.Inject
+
+class RedisSharedCacheSet @Inject constructor(
+    private val redisConnection: RedisConnection,
+): SharedCacheSet {
+
+    override lateinit var key: String
+
+    override fun has(value: String): Boolean {
+        return redisConnection.resource().use {
+            it.sismember(key, value)
+        }
+    }
+
+    override fun add(value: String) {
+        redisConnection.resource().use {
+            it.sadd(key, value)
+        }
+    }
+
+    override fun add(values: List<String>) {
+        redisConnection.resource().use {
+            values.forEach { value -> it.sadd(key, value) }
+        }
+    }
+
+    override fun remove(value: String) {
+        redisConnection.resource().use {
+            it.srem(key, value)
+        }
+    }
+
+    override fun removeAll() {
+        redisConnection.resource().use {
+            it.del(key)
+        }
+    }
+
+    override fun all(): Set<String> {
+        return redisConnection.resource().use {
+            it.smembers(key)
+        }
+    }
+}

--- a/src/main/kotlin/com/projectcitybuild/platforms/bungeecord/BungeecordComponent.kt
+++ b/src/main/kotlin/com/projectcitybuild/platforms/bungeecord/BungeecordComponent.kt
@@ -2,12 +2,12 @@ package com.projectcitybuild.platforms.bungeecord
 
 import com.projectcitybuild.core.contracts.BungeecordFeatureModule
 import com.projectcitybuild.modules.config.PlatformConfig
-import com.projectcitybuild.modules.database.DataSourceProvider
+import com.projectcitybuild.core.infrastructure.database.DataSourceProvider
 import com.projectcitybuild.modules.datetime.DateTimeProvider
 import com.projectcitybuild.modules.errorreporting.ErrorReporterProvider
 import com.projectcitybuild.modules.logger.PlatformLogger
-import com.projectcitybuild.modules.network.APIClient
-import com.projectcitybuild.modules.network.NetworkProvider
+import com.projectcitybuild.core.infrastructure.network.APIClient
+import com.projectcitybuild.core.infrastructure.network.NetworkProvider
 import com.projectcitybuild.modules.permissions.PermissionsProvider
 import com.projectcitybuild.modules.proxyadapter.BungeecordProxyAdapterModule
 import com.projectcitybuild.modules.scheduler.PlatformScheduler

--- a/src/main/kotlin/com/projectcitybuild/platforms/bungeecord/BungeecordPlatform.kt
+++ b/src/main/kotlin/com/projectcitybuild/platforms/bungeecord/BungeecordPlatform.kt
@@ -4,11 +4,11 @@ import com.projectcitybuild.core.contracts.BungeecordFeatureModule
 import com.projectcitybuild.entities.Channel
 import com.projectcitybuild.modules.channels.bungeecord.BungeecordMessageListener
 import com.projectcitybuild.modules.config.implementations.BungeecordConfig
-import com.projectcitybuild.modules.database.DataSource
+import com.projectcitybuild.core.infrastructure.database.DataSource
 import com.projectcitybuild.modules.errorreporting.ErrorReporter
 import com.projectcitybuild.modules.logger.PlatformLogger
 import com.projectcitybuild.modules.logger.implementations.BungeecordLogger
-import com.projectcitybuild.modules.network.APIClientImpl
+import com.projectcitybuild.core.infrastructure.network.APIClientImpl
 import com.projectcitybuild.modules.permissions.Permissions
 import com.projectcitybuild.modules.playerconfig.PlayerConfigCache
 import com.projectcitybuild.modules.scheduler.implementations.BungeecordScheduler

--- a/src/main/kotlin/com/projectcitybuild/platforms/spigot/SpigotComponent.kt
+++ b/src/main/kotlin/com/projectcitybuild/platforms/spigot/SpigotComponent.kt
@@ -1,14 +1,14 @@
 package com.projectcitybuild.platforms.spigot
 
 import com.projectcitybuild.modules.config.PlatformConfig
-import com.projectcitybuild.modules.database.DataSourceProvider
+import com.projectcitybuild.core.infrastructure.database.DataSourceProvider
 import com.projectcitybuild.modules.datetime.DateTimeProvider
 import com.projectcitybuild.modules.errorreporting.ErrorReporterProvider
 import com.projectcitybuild.modules.eventbroadcast.LocalEventBroadcaster
 import com.projectcitybuild.modules.logger.PlatformLogger
-import com.projectcitybuild.modules.network.APIClient
-import com.projectcitybuild.modules.network.NetworkProvider
-import com.projectcitybuild.modules.redis.RedisProvider
+import com.projectcitybuild.core.infrastructure.network.APIClient
+import com.projectcitybuild.core.infrastructure.network.NetworkProvider
+import com.projectcitybuild.core.infrastructure.redis.RedisProvider
 import com.projectcitybuild.modules.scheduler.PlatformScheduler
 import dagger.BindsInstance
 import dagger.Component

--- a/src/main/kotlin/com/projectcitybuild/platforms/spigot/SpigotComponent.kt
+++ b/src/main/kotlin/com/projectcitybuild/platforms/spigot/SpigotComponent.kt
@@ -10,10 +10,13 @@ import com.projectcitybuild.core.infrastructure.network.APIClient
 import com.projectcitybuild.core.infrastructure.network.NetworkProvider
 import com.projectcitybuild.core.infrastructure.redis.RedisProvider
 import com.projectcitybuild.modules.scheduler.PlatformScheduler
+import com.projectcitybuild.modules.sharedcache.SharedCacheSetProvider
 import dagger.BindsInstance
 import dagger.Component
 import org.bukkit.plugin.Plugin
 import org.bukkit.plugin.java.JavaPlugin
+import java.io.File
+import javax.inject.Qualifier
 import javax.inject.Singleton
 
 @Singleton
@@ -23,6 +26,7 @@ import javax.inject.Singleton
     NetworkProvider::class,
     DataSourceProvider::class,
     RedisProvider::class,
+    SharedCacheSetProvider::class,
 ])
 interface SpigotComponent {
 
@@ -50,6 +54,9 @@ interface SpigotComponent {
 
         @BindsInstance
         fun apiClient(apiClient: APIClient): Builder
+
+        @BindsInstance
+        fun baseFolder(baseFolder: File): Builder
 
         fun build(): SpigotComponent
     }

--- a/src/main/kotlin/com/projectcitybuild/platforms/spigot/SpigotPlatform.kt
+++ b/src/main/kotlin/com/projectcitybuild/platforms/spigot/SpigotPlatform.kt
@@ -4,13 +4,13 @@ import com.github.shynixn.mccoroutine.minecraftDispatcher
 import com.projectcitybuild.entities.Channel
 import com.projectcitybuild.modules.channels.spigot.SpigotMessageListener
 import com.projectcitybuild.modules.config.implementations.SpigotConfig
-import com.projectcitybuild.modules.database.DataSource
+import com.projectcitybuild.core.infrastructure.database.DataSource
 import com.projectcitybuild.modules.errorreporting.ErrorReporter
 import com.projectcitybuild.modules.eventbroadcast.implementations.SpigotLocalEventBroadcaster
 import com.projectcitybuild.modules.logger.PlatformLogger
 import com.projectcitybuild.modules.logger.implementations.SpigotLogger
-import com.projectcitybuild.modules.network.APIClientImpl
-import com.projectcitybuild.modules.redis.RedisConnection
+import com.projectcitybuild.core.infrastructure.network.APIClientImpl
+import com.projectcitybuild.core.infrastructure.redis.RedisConnection
 import com.projectcitybuild.modules.scheduler.implementations.SpigotScheduler
 import com.projectcitybuild.platforms.spigot.environment.SpigotCommandRegistry
 import com.projectcitybuild.platforms.spigot.environment.SpigotListenerRegistry

--- a/src/main/kotlin/com/projectcitybuild/platforms/spigot/SpigotPlatform.kt
+++ b/src/main/kotlin/com/projectcitybuild/platforms/spigot/SpigotPlatform.kt
@@ -31,6 +31,7 @@ class SpigotPlatform: JavaPlugin() {
             .scheduler(SpigotScheduler(this))
             .localEventBroadcaster(SpigotLocalEventBroadcaster())
             .apiClient(APIClientImpl { this.minecraftDispatcher })
+            .baseFolder(dataFolder)
             .build()
 
         container = component.container()

--- a/src/main/kotlin/com/projectcitybuild/platforms/spigot/SpigotPlatform.kt
+++ b/src/main/kotlin/com/projectcitybuild/platforms/spigot/SpigotPlatform.kt
@@ -1,16 +1,18 @@
 package com.projectcitybuild.platforms.spigot
 
 import com.github.shynixn.mccoroutine.minecraftDispatcher
-import com.projectcitybuild.entities.Channel
-import com.projectcitybuild.modules.channels.spigot.SpigotMessageListener
-import com.projectcitybuild.modules.config.implementations.SpigotConfig
 import com.projectcitybuild.core.infrastructure.database.DataSource
+import com.projectcitybuild.core.infrastructure.network.APIClientImpl
+import com.projectcitybuild.core.infrastructure.redis.RedisConnection
+import com.projectcitybuild.entities.Channel
+import com.projectcitybuild.entities.PluginConfig
+import com.projectcitybuild.modules.channels.spigot.SpigotMessageListener
+import com.projectcitybuild.modules.config.PlatformConfig
+import com.projectcitybuild.modules.config.implementations.SpigotConfig
 import com.projectcitybuild.modules.errorreporting.ErrorReporter
 import com.projectcitybuild.modules.eventbroadcast.implementations.SpigotLocalEventBroadcaster
 import com.projectcitybuild.modules.logger.PlatformLogger
 import com.projectcitybuild.modules.logger.implementations.SpigotLogger
-import com.projectcitybuild.core.infrastructure.network.APIClientImpl
-import com.projectcitybuild.core.infrastructure.redis.RedisConnection
 import com.projectcitybuild.modules.scheduler.implementations.SpigotScheduler
 import com.projectcitybuild.platforms.spigot.environment.SpigotCommandRegistry
 import com.projectcitybuild.platforms.spigot.environment.SpigotListenerRegistry
@@ -45,6 +47,7 @@ class SpigotPlatform: JavaPlugin() {
     class Container @Inject constructor(
         private val modulesContainer: SpigotModulesContainer,
         private val plugin: Plugin,
+        private val config: PlatformConfig,
         private val logger: PlatformLogger,
         private val commandRegistry: SpigotCommandRegistry,
         private val listenerRegistry: SpigotListenerRegistry,
@@ -52,12 +55,18 @@ class SpigotPlatform: JavaPlugin() {
         private val errorReporter: ErrorReporter,
         private val redisConnection: RedisConnection,
     ) {
+        private val isRedisEnabled: Boolean
+            get() = config.get(PluginConfig.SHARED_CACHE_ADAPTER) == "redis"
+
         fun onEnable(server: Server) {
             errorReporter.bootstrap()
 
             runCatching {
-                redisConnection.connect()
                 dataSource.connect()
+
+                if (isRedisEnabled) {
+                    redisConnection.connect()
+                }
 
                 val pluginMessageListener = SpigotMessageListener(logger)
                 server.messenger.registerOutgoingPluginChannel(plugin, Channel.BUNGEECORD)
@@ -88,7 +97,10 @@ class SpigotPlatform: JavaPlugin() {
                 listenerRegistry.unregisterAll()
 
                 dataSource.disconnect()
-                redisConnection.disconnect()
+
+                if (isRedisEnabled) {
+                    redisConnection.disconnect()
+                }
 
             }.onFailure { reportError(it) }
         }

--- a/src/test/com/projectcitybuild/features/ranksync/usecases/GenerateAccountVerificationURLUseCaseTest.kt
+++ b/src/test/com/projectcitybuild/features/ranksync/usecases/GenerateAccountVerificationURLUseCaseTest.kt
@@ -5,10 +5,10 @@ import com.projectcitybuild.core.utilities.Success
 import com.projectcitybuild.entities.responses.ApiError
 import com.projectcitybuild.entities.responses.ApiResponse
 import com.projectcitybuild.entities.responses.AuthURL
-import com.projectcitybuild.modules.network.APIClient
-import com.projectcitybuild.modules.network.APIClientMock
-import com.projectcitybuild.modules.network.APIRequestFactory
-import com.projectcitybuild.modules.network.pcb.client.PCBClient
+import com.projectcitybuild.core.infrastructure.network.APIClient
+import com.projectcitybuild.core.infrastructure.network.APIClientMock
+import com.projectcitybuild.core.infrastructure.network.APIRequestFactory
+import com.projectcitybuild.core.infrastructure.network.pcb.client.PCBClient
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach

--- a/src/test/com/projectcitybuild/features/ranksync/usecases/UpdatePlayerGroupsUseCaseTest.kt
+++ b/src/test/com/projectcitybuild/features/ranksync/usecases/UpdatePlayerGroupsUseCaseTest.kt
@@ -8,10 +8,10 @@ import com.projectcitybuild.entities.responses.ApiResponse
 import com.projectcitybuild.entities.responses.AuthPlayerGroups
 import com.projectcitybuild.entities.responses.Group
 import com.projectcitybuild.modules.config.PlatformConfig
-import com.projectcitybuild.modules.network.APIClient
-import com.projectcitybuild.modules.network.APIClientMock
-import com.projectcitybuild.modules.network.APIRequestFactory
-import com.projectcitybuild.modules.network.pcb.client.PCBClient
+import com.projectcitybuild.core.infrastructure.network.APIClient
+import com.projectcitybuild.core.infrastructure.network.APIClientMock
+import com.projectcitybuild.core.infrastructure.network.APIRequestFactory
+import com.projectcitybuild.core.infrastructure.network.pcb.client.PCBClient
 import com.projectcitybuild.modules.permissions.Permissions
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals


### PR DESCRIPTION
## Overview

Allows the Redis cache to be swapped out (via config file) with a cache that saves and reads to a flat file.

The idea is that this will allow you to run the plugin without Redis installed by having all the servers read/write to the same file, however it should only be done in a dev environment because it's _very inefficient_ (due to IO bottleneck and locking).

## Usage 

To switch to the Flat File cache, edit the `config.yml` file of each Spigot server so that the shared cache uses `flatfile` instead of `redis`:

```
shared_cache:
    adapter: flatfile
    flatfile:
        relative_path: ../../cache/pcbridge
```

All Spigot servers should point to the same location (i.e. the relative path should resolve to the same folder on disk somewhere)