### PR TITLE
Allow API to be disabled via config

### DIFF
--- a/src/main/kotlin/com/projectcitybuild/core/infrastructure/database/DataSourceProvider.kt
+++ b/src/main/kotlin/com/projectcitybuild/core/infrastructure/database/DataSourceProvider.kt
@@ -1,6 +1,6 @@
 package com.projectcitybuild.core.infrastructure.database
 
-import com.projectcitybuild.entities.PluginConfig
+import com.projectcitybuild.modules.config.PluginConfig
 import com.projectcitybuild.modules.config.PlatformConfig
 import com.projectcitybuild.modules.logger.PlatformLogger
 import dagger.Module

--- a/src/main/kotlin/com/projectcitybuild/core/infrastructure/database/DataSourceProvider.kt
+++ b/src/main/kotlin/com/projectcitybuild/core/infrastructure/database/DataSourceProvider.kt
@@ -1,6 +1,6 @@
 package com.projectcitybuild.core.infrastructure.database
 
-import com.projectcitybuild.modules.config.ConfigKeys
+import com.projectcitybuild.modules.config.ConfigKey
 import com.projectcitybuild.modules.config.PlatformConfig
 import com.projectcitybuild.modules.logger.PlatformLogger
 import dagger.Module
@@ -18,11 +18,11 @@ class DataSourceProvider {
     ): DataSource {
         return DataSource(
             logger = logger,
-            hostName = config.get(ConfigKeys.DB_HOSTNAME),
-            port = config.get(ConfigKeys.DB_PORT),
-            databaseName = config.get(ConfigKeys.DB_NAME),
-            username = config.get(ConfigKeys.DB_USERNAME),
-            password = config.get(ConfigKeys.DB_PASSWORD),
+            hostName = config.get(ConfigKey.DB_HOSTNAME),
+            port = config.get(ConfigKey.DB_PORT),
+            databaseName = config.get(ConfigKey.DB_NAME),
+            username = config.get(ConfigKey.DB_USERNAME),
+            password = config.get(ConfigKey.DB_PASSWORD),
             shouldRunMigrations = true
         )
     }

--- a/src/main/kotlin/com/projectcitybuild/core/infrastructure/database/DataSourceProvider.kt
+++ b/src/main/kotlin/com/projectcitybuild/core/infrastructure/database/DataSourceProvider.kt
@@ -1,6 +1,6 @@
 package com.projectcitybuild.core.infrastructure.database
 
-import com.projectcitybuild.modules.config.PluginConfig
+import com.projectcitybuild.modules.config.ConfigKeys
 import com.projectcitybuild.modules.config.PlatformConfig
 import com.projectcitybuild.modules.logger.PlatformLogger
 import dagger.Module
@@ -18,11 +18,11 @@ class DataSourceProvider {
     ): DataSource {
         return DataSource(
             logger = logger,
-            hostName = config.get(PluginConfig.DB_HOSTNAME),
-            port = config.get(PluginConfig.DB_PORT),
-            databaseName = config.get(PluginConfig.DB_NAME),
-            username = config.get(PluginConfig.DB_USERNAME),
-            password = config.get(PluginConfig.DB_PASSWORD),
+            hostName = config.get(ConfigKeys.DB_HOSTNAME),
+            port = config.get(ConfigKeys.DB_PORT),
+            databaseName = config.get(ConfigKeys.DB_NAME),
+            username = config.get(ConfigKeys.DB_USERNAME),
+            password = config.get(ConfigKeys.DB_PASSWORD),
             shouldRunMigrations = true
         )
     }

--- a/src/main/kotlin/com/projectcitybuild/core/infrastructure/network/NetworkProvider.kt
+++ b/src/main/kotlin/com/projectcitybuild/core/infrastructure/network/NetworkProvider.kt
@@ -1,6 +1,6 @@
 package com.projectcitybuild.core.infrastructure.network
 
-import com.projectcitybuild.entities.PluginConfig
+import com.projectcitybuild.modules.config.PluginConfig
 import com.projectcitybuild.modules.config.PlatformConfig
 import com.projectcitybuild.core.infrastructure.network.mojang.client.MojangClient
 import com.projectcitybuild.core.infrastructure.network.pcb.client.PCBClient

--- a/src/main/kotlin/com/projectcitybuild/core/infrastructure/network/NetworkProvider.kt
+++ b/src/main/kotlin/com/projectcitybuild/core/infrastructure/network/NetworkProvider.kt
@@ -1,6 +1,6 @@
 package com.projectcitybuild.core.infrastructure.network
 
-import com.projectcitybuild.modules.config.PluginConfig
+import com.projectcitybuild.modules.config.ConfigKeys
 import com.projectcitybuild.modules.config.PlatformConfig
 import com.projectcitybuild.core.infrastructure.network.mojang.client.MojangClient
 import com.projectcitybuild.core.infrastructure.network.pcb.client.PCBClient
@@ -12,12 +12,12 @@ class NetworkProvider {
 
     @Provides
     fun provideAPIRequestFactory(config: PlatformConfig): APIRequestFactory {
-        val isLoggingEnabled = config.get(PluginConfig.API_IS_LOGGING_ENABLED)
+        val isLoggingEnabled = config.get(ConfigKeys.API_IS_LOGGING_ENABLED)
 
         return APIRequestFactory(
             pcb = PCBClient(
-                authToken = config.get(PluginConfig.API_KEY),
-                baseUrl = config.get(PluginConfig.API_BASE_URL),
+                authToken = config.get(ConfigKeys.API_KEY),
+                baseUrl = config.get(ConfigKeys.API_BASE_URL),
                 withLogging = isLoggingEnabled
             ),
             mojang = MojangClient(

--- a/src/main/kotlin/com/projectcitybuild/core/infrastructure/network/NetworkProvider.kt
+++ b/src/main/kotlin/com/projectcitybuild/core/infrastructure/network/NetworkProvider.kt
@@ -1,6 +1,6 @@
 package com.projectcitybuild.core.infrastructure.network
 
-import com.projectcitybuild.modules.config.ConfigKeys
+import com.projectcitybuild.modules.config.ConfigKey
 import com.projectcitybuild.modules.config.PlatformConfig
 import com.projectcitybuild.core.infrastructure.network.mojang.client.MojangClient
 import com.projectcitybuild.core.infrastructure.network.pcb.client.PCBClient
@@ -12,12 +12,12 @@ class NetworkProvider {
 
     @Provides
     fun provideAPIRequestFactory(config: PlatformConfig): APIRequestFactory {
-        val isLoggingEnabled = config.get(ConfigKeys.API_IS_LOGGING_ENABLED)
+        val isLoggingEnabled = config.get(ConfigKey.API_IS_LOGGING_ENABLED)
 
         return APIRequestFactory(
             pcb = PCBClient(
-                authToken = config.get(ConfigKeys.API_KEY),
-                baseUrl = config.get(ConfigKeys.API_BASE_URL),
+                authToken = config.get(ConfigKey.API_KEY),
+                baseUrl = config.get(ConfigKey.API_BASE_URL),
                 withLogging = isLoggingEnabled
             ),
             mojang = MojangClient(

--- a/src/main/kotlin/com/projectcitybuild/core/infrastructure/redis/RedisProvider.kt
+++ b/src/main/kotlin/com/projectcitybuild/core/infrastructure/redis/RedisProvider.kt
@@ -1,6 +1,6 @@
 package com.projectcitybuild.core.infrastructure.redis
 
-import com.projectcitybuild.modules.config.ConfigKeys
+import com.projectcitybuild.modules.config.ConfigKey
 import com.projectcitybuild.modules.config.PlatformConfig
 import dagger.Module
 import dagger.Provides
@@ -13,10 +13,10 @@ class RedisProvider {
     @Singleton
     fun provideRedisConnection(config: PlatformConfig): RedisConnection {
         return RedisConnection(
-            hostname = config.get(ConfigKeys.REDIS_HOSTNAME),
-            port = config.get(ConfigKeys.REDIS_PORT),
-            username = config.get(ConfigKeys.REDIS_USERNAME),
-            password = config.get(ConfigKeys.REDIS_PASSWORD),
+            hostname = config.get(ConfigKey.REDIS_HOSTNAME),
+            port = config.get(ConfigKey.REDIS_PORT),
+            username = config.get(ConfigKey.REDIS_USERNAME),
+            password = config.get(ConfigKey.REDIS_PASSWORD),
         )
     }
 }

--- a/src/main/kotlin/com/projectcitybuild/core/infrastructure/redis/RedisProvider.kt
+++ b/src/main/kotlin/com/projectcitybuild/core/infrastructure/redis/RedisProvider.kt
@@ -1,6 +1,6 @@
 package com.projectcitybuild.core.infrastructure.redis
 
-import com.projectcitybuild.entities.PluginConfig
+import com.projectcitybuild.modules.config.PluginConfig
 import com.projectcitybuild.modules.config.PlatformConfig
 import dagger.Module
 import dagger.Provides

--- a/src/main/kotlin/com/projectcitybuild/core/infrastructure/redis/RedisProvider.kt
+++ b/src/main/kotlin/com/projectcitybuild/core/infrastructure/redis/RedisProvider.kt
@@ -1,6 +1,6 @@
 package com.projectcitybuild.core.infrastructure.redis
 
-import com.projectcitybuild.modules.config.PluginConfig
+import com.projectcitybuild.modules.config.ConfigKeys
 import com.projectcitybuild.modules.config.PlatformConfig
 import dagger.Module
 import dagger.Provides
@@ -13,10 +13,10 @@ class RedisProvider {
     @Singleton
     fun provideRedisConnection(config: PlatformConfig): RedisConnection {
         return RedisConnection(
-            hostname = config.get(PluginConfig.REDIS_HOSTNAME),
-            port = config.get(PluginConfig.REDIS_PORT),
-            username = config.get(PluginConfig.REDIS_USERNAME),
-            password = config.get(PluginConfig.REDIS_PASSWORD),
+            hostname = config.get(ConfigKeys.REDIS_HOSTNAME),
+            port = config.get(ConfigKeys.REDIS_PORT),
+            username = config.get(ConfigKeys.REDIS_USERNAME),
+            password = config.get(ConfigKeys.REDIS_PASSWORD),
         )
     }
 }

--- a/src/main/kotlin/com/projectcitybuild/features/bans/BanModule.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/bans/BanModule.kt
@@ -3,6 +3,8 @@ package com.projectcitybuild.features.bans
 import com.projectcitybuild.core.contracts.BungeecordFeatureModule
 import com.projectcitybuild.features.bans.commands.*
 import com.projectcitybuild.features.bans.listeners.BanConnectionListener
+import com.projectcitybuild.modules.config.ConfigKey
+import com.projectcitybuild.modules.config.PlatformConfig
 import com.projectcitybuild.platforms.bungeecord.environment.BungeecordCommand
 import net.md_5.bungee.api.plugin.Listener
 import javax.inject.Inject
@@ -13,18 +15,23 @@ class BanModule @Inject constructor(
     unbanCommand: UnbanCommand,
     unbanIPCommand: UnbanIPCommand,
     checkBanCommand: CheckBanCommand,
-    banConnectionListener: BanConnectionListener
+    banConnectionListener: BanConnectionListener,
+    config: PlatformConfig,
 ): BungeecordFeatureModule {
 
-    override val bungeecordCommands: Array<BungeecordCommand> = arrayOf(
-        banCommand,
-        banIPCommand,
-        unbanCommand,
-        unbanIPCommand,
-        checkBanCommand,
-    )
+    override val bungeecordCommands: Array<BungeecordCommand> =
+        if (config.get(ConfigKey.API_ENABLED)) arrayOf(
+            banCommand,
+            banIPCommand,
+            unbanCommand,
+            unbanIPCommand,
+            checkBanCommand,
+        )
+        else emptyArray()
 
-    override val bungeecordListeners: Array<Listener> = arrayOf(
-        banConnectionListener,
-    )
+    override val bungeecordListeners: Array<Listener> =
+        if (config.get(ConfigKey.API_ENABLED)) arrayOf(
+            banConnectionListener,
+        )
+        else emptyArray()
 }

--- a/src/main/kotlin/com/projectcitybuild/features/chat/ChatGroupFormatBuilder.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/chat/ChatGroupFormatBuilder.kt
@@ -1,6 +1,6 @@
 package com.projectcitybuild.features.chat
 
-import com.projectcitybuild.modules.config.ConfigKeys
+import com.projectcitybuild.modules.config.ConfigKey
 import com.projectcitybuild.modules.config.PlatformConfig
 import com.projectcitybuild.modules.permissions.Permissions
 import net.md_5.bungee.api.chat.BaseComponent
@@ -20,9 +20,9 @@ class ChatGroupFormatBuilder @Inject constructor(
         val groups: TextComponent,
     )
 
-    private val trustedGroups = config.get(ConfigKeys.GROUPS_TRUST_PRIORITY)
-    private val builderGroups = config.get(ConfigKeys.GROUPS_BUILD_PRIORITY)
-    private val donorGroups = config.get(ConfigKeys.GROUPS_DONOR_PRIORITY)
+    private val trustedGroups = config.get(ConfigKey.GROUPS_TRUST_PRIORITY)
+    private val builderGroups = config.get(ConfigKey.GROUPS_BUILD_PRIORITY)
+    private val donorGroups = config.get(ConfigKey.GROUPS_DONOR_PRIORITY)
 
     fun format(player: ProxiedPlayer): Aggregate {
         val groupNames = permissions.getUserGroups(player.uniqueId)

--- a/src/main/kotlin/com/projectcitybuild/features/chat/ChatGroupFormatBuilder.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/chat/ChatGroupFormatBuilder.kt
@@ -1,6 +1,6 @@
 package com.projectcitybuild.features.chat
 
-import com.projectcitybuild.entities.PluginConfig
+import com.projectcitybuild.modules.config.PluginConfig
 import com.projectcitybuild.modules.config.PlatformConfig
 import com.projectcitybuild.modules.permissions.Permissions
 import net.md_5.bungee.api.chat.BaseComponent

--- a/src/main/kotlin/com/projectcitybuild/features/chat/ChatGroupFormatBuilder.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/chat/ChatGroupFormatBuilder.kt
@@ -1,6 +1,6 @@
 package com.projectcitybuild.features.chat
 
-import com.projectcitybuild.modules.config.PluginConfig
+import com.projectcitybuild.modules.config.ConfigKeys
 import com.projectcitybuild.modules.config.PlatformConfig
 import com.projectcitybuild.modules.permissions.Permissions
 import net.md_5.bungee.api.chat.BaseComponent
@@ -20,9 +20,9 @@ class ChatGroupFormatBuilder @Inject constructor(
         val groups: TextComponent,
     )
 
-    private val trustedGroups = config.get(PluginConfig.GROUPS_TRUST_PRIORITY)
-    private val builderGroups = config.get(PluginConfig.GROUPS_BUILD_PRIORITY)
-    private val donorGroups = config.get(PluginConfig.GROUPS_DONOR_PRIORITY)
+    private val trustedGroups = config.get(ConfigKeys.GROUPS_TRUST_PRIORITY)
+    private val builderGroups = config.get(ConfigKeys.GROUPS_BUILD_PRIORITY)
+    private val donorGroups = config.get(ConfigKeys.GROUPS_DONOR_PRIORITY)
 
     fun format(player: ProxiedPlayer): Aggregate {
         val groupNames = permissions.getUserGroups(player.uniqueId)

--- a/src/main/kotlin/com/projectcitybuild/features/hub/commands/HubCommand.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/hub/commands/HubCommand.kt
@@ -1,7 +1,7 @@
 package com.projectcitybuild.features.hub.commands
 
 import com.projectcitybuild.core.InvalidCommandArgumentsException
-import com.projectcitybuild.entities.PluginConfig
+import com.projectcitybuild.modules.config.PluginConfig
 import com.projectcitybuild.entities.SubChannel
 import com.projectcitybuild.entities.Warp
 import com.projectcitybuild.features.hub.repositories.HubRepository

--- a/src/main/kotlin/com/projectcitybuild/features/hub/commands/HubCommand.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/hub/commands/HubCommand.kt
@@ -1,7 +1,7 @@
 package com.projectcitybuild.features.hub.commands
 
 import com.projectcitybuild.core.InvalidCommandArgumentsException
-import com.projectcitybuild.modules.config.ConfigKeys
+import com.projectcitybuild.modules.config.ConfigKey
 import com.projectcitybuild.entities.SubChannel
 import com.projectcitybuild.entities.Warp
 import com.projectcitybuild.features.hub.repositories.HubRepository
@@ -52,7 +52,7 @@ class HubCommand @Inject constructor(
             PlayerPreWarpEvent(input.sender, input.sender.location)
         )
 
-        val currentServerName = config.get(ConfigKeys.SPIGOT_SERVER_NAME)
+        val currentServerName = config.get(ConfigKey.SPIGOT_SERVER_NAME)
         val isHubOnSameServer = currentServerName == hub.serverName
         if (isHubOnSameServer) {
             val worldName = hub.worldName

--- a/src/main/kotlin/com/projectcitybuild/features/hub/commands/HubCommand.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/hub/commands/HubCommand.kt
@@ -1,7 +1,7 @@
 package com.projectcitybuild.features.hub.commands
 
 import com.projectcitybuild.core.InvalidCommandArgumentsException
-import com.projectcitybuild.modules.config.PluginConfig
+import com.projectcitybuild.modules.config.ConfigKeys
 import com.projectcitybuild.entities.SubChannel
 import com.projectcitybuild.entities.Warp
 import com.projectcitybuild.features.hub.repositories.HubRepository
@@ -52,7 +52,7 @@ class HubCommand @Inject constructor(
             PlayerPreWarpEvent(input.sender, input.sender.location)
         )
 
-        val currentServerName = config.get(PluginConfig.SPIGOT_SERVER_NAME)
+        val currentServerName = config.get(ConfigKeys.SPIGOT_SERVER_NAME)
         val isHubOnSameServer = currentServerName == hub.serverName
         if (isHubOnSameServer) {
             val worldName = hub.worldName

--- a/src/main/kotlin/com/projectcitybuild/features/hub/commands/SetHubCommand.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/hub/commands/SetHubCommand.kt
@@ -2,7 +2,7 @@ package com.projectcitybuild.features.hub.commands
 
 import com.projectcitybuild.core.InvalidCommandArgumentsException
 import com.projectcitybuild.entities.CrossServerLocation
-import com.projectcitybuild.modules.config.PluginConfig
+import com.projectcitybuild.modules.config.ConfigKeys
 import com.projectcitybuild.features.hub.repositories.HubRepository
 import com.projectcitybuild.modules.config.PlatformConfig
 import com.projectcitybuild.modules.textcomponentbuilder.send
@@ -30,7 +30,7 @@ class SetHubCommand @Inject constructor(
         }
         val playerLocation = input.sender.location
         val location = CrossServerLocation(
-            serverName = config.get(PluginConfig.SPIGOT_SERVER_NAME),
+            serverName = config.get(ConfigKeys.SPIGOT_SERVER_NAME),
             playerLocation.world.name,
             playerLocation.x,
             playerLocation.y,

--- a/src/main/kotlin/com/projectcitybuild/features/hub/commands/SetHubCommand.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/hub/commands/SetHubCommand.kt
@@ -2,7 +2,7 @@ package com.projectcitybuild.features.hub.commands
 
 import com.projectcitybuild.core.InvalidCommandArgumentsException
 import com.projectcitybuild.entities.CrossServerLocation
-import com.projectcitybuild.entities.PluginConfig
+import com.projectcitybuild.modules.config.PluginConfig
 import com.projectcitybuild.features.hub.repositories.HubRepository
 import com.projectcitybuild.modules.config.PlatformConfig
 import com.projectcitybuild.modules.textcomponentbuilder.send

--- a/src/main/kotlin/com/projectcitybuild/features/hub/commands/SetHubCommand.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/hub/commands/SetHubCommand.kt
@@ -2,7 +2,7 @@ package com.projectcitybuild.features.hub.commands
 
 import com.projectcitybuild.core.InvalidCommandArgumentsException
 import com.projectcitybuild.entities.CrossServerLocation
-import com.projectcitybuild.modules.config.ConfigKeys
+import com.projectcitybuild.modules.config.ConfigKey
 import com.projectcitybuild.features.hub.repositories.HubRepository
 import com.projectcitybuild.modules.config.PlatformConfig
 import com.projectcitybuild.modules.textcomponentbuilder.send
@@ -30,7 +30,7 @@ class SetHubCommand @Inject constructor(
         }
         val playerLocation = input.sender.location
         val location = CrossServerLocation(
-            serverName = config.get(ConfigKeys.SPIGOT_SERVER_NAME),
+            serverName = config.get(ConfigKey.SPIGOT_SERVER_NAME),
             playerLocation.world.name,
             playerLocation.x,
             playerLocation.y,

--- a/src/main/kotlin/com/projectcitybuild/features/ranksync/RankSyncModule.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/ranksync/RankSyncModule.kt
@@ -4,6 +4,8 @@ import com.projectcitybuild.core.contracts.BungeecordFeatureModule
 import com.projectcitybuild.features.ranksync.commands.SyncCommand
 import com.projectcitybuild.features.ranksync.commands.SyncOtherCommand
 import com.projectcitybuild.features.ranksync.listeners.SyncRankLoginListener
+import com.projectcitybuild.modules.config.ConfigKey
+import com.projectcitybuild.modules.config.PlatformConfig
 import com.projectcitybuild.platforms.bungeecord.environment.BungeecordCommand
 import net.md_5.bungee.api.plugin.Listener
 import javax.inject.Inject
@@ -12,14 +14,19 @@ class RankSyncModule @Inject constructor(
     syncCommand: SyncCommand,
     syncOtherCommand: SyncOtherCommand,
     syncRankLoginListener: SyncRankLoginListener,
+    config: PlatformConfig,
 ): BungeecordFeatureModule {
 
-    override val bungeecordCommands: Array<BungeecordCommand> = arrayOf(
-        syncCommand,
-        syncOtherCommand,
-    )
+    override val bungeecordCommands: Array<BungeecordCommand> =
+        if (config.get(ConfigKey.API_ENABLED)) arrayOf(
+            syncCommand,
+            syncOtherCommand,
+        )
+        else emptyArray()
 
-    override val bungeecordListeners: Array<Listener> = arrayOf(
-        syncRankLoginListener,
-    )
+    override val bungeecordListeners: Array<Listener> =
+        if (config.get(ConfigKey.API_ENABLED)) arrayOf(
+            syncRankLoginListener,
+        )
+        else emptyArray()
 }

--- a/src/main/kotlin/com/projectcitybuild/features/ranksync/usecases/UpdatePlayerGroupsUseCase.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/ranksync/usecases/UpdatePlayerGroupsUseCase.kt
@@ -3,7 +3,7 @@ package com.projectcitybuild.features.ranksync.usecases
 import com.projectcitybuild.core.utilities.Failure
 import com.projectcitybuild.core.utilities.Result
 import com.projectcitybuild.core.utilities.Success
-import com.projectcitybuild.entities.PluginConfig
+import com.projectcitybuild.modules.config.PluginConfig
 import com.projectcitybuild.entities.responses.Group
 import com.projectcitybuild.modules.config.PlatformConfig
 import com.projectcitybuild.core.infrastructure.network.APIClient

--- a/src/main/kotlin/com/projectcitybuild/features/ranksync/usecases/UpdatePlayerGroupsUseCase.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/ranksync/usecases/UpdatePlayerGroupsUseCase.kt
@@ -3,7 +3,7 @@ package com.projectcitybuild.features.ranksync.usecases
 import com.projectcitybuild.core.utilities.Failure
 import com.projectcitybuild.core.utilities.Result
 import com.projectcitybuild.core.utilities.Success
-import com.projectcitybuild.modules.config.ConfigKeys
+import com.projectcitybuild.modules.config.ConfigKey
 import com.projectcitybuild.entities.responses.Group
 import com.projectcitybuild.modules.config.PlatformConfig
 import com.projectcitybuild.core.infrastructure.network.APIClient
@@ -38,7 +38,7 @@ class UpdatePlayerGroupsUseCase @Inject constructor(
 
         val groupNames = groups
             .mapNotNull { it.minecraftName }
-            .ifEmpty { listOf(config.get(ConfigKeys.GROUPS_GUEST)) }
+            .ifEmpty { listOf(config.get(ConfigKey.GROUPS_GUEST)) }
 
         permissions.setUserGroups(playerUUID, groupNames)
 

--- a/src/main/kotlin/com/projectcitybuild/features/ranksync/usecases/UpdatePlayerGroupsUseCase.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/ranksync/usecases/UpdatePlayerGroupsUseCase.kt
@@ -3,7 +3,7 @@ package com.projectcitybuild.features.ranksync.usecases
 import com.projectcitybuild.core.utilities.Failure
 import com.projectcitybuild.core.utilities.Result
 import com.projectcitybuild.core.utilities.Success
-import com.projectcitybuild.modules.config.PluginConfig
+import com.projectcitybuild.modules.config.ConfigKeys
 import com.projectcitybuild.entities.responses.Group
 import com.projectcitybuild.modules.config.PlatformConfig
 import com.projectcitybuild.core.infrastructure.network.APIClient
@@ -38,7 +38,7 @@ class UpdatePlayerGroupsUseCase @Inject constructor(
 
         val groupNames = groups
             .mapNotNull { it.minecraftName }
-            .ifEmpty { listOf(config.get(PluginConfig.GROUPS_GUEST)) }
+            .ifEmpty { listOf(config.get(ConfigKeys.GROUPS_GUEST)) }
 
         permissions.setUserGroups(playerUUID, groupNames)
 

--- a/src/main/kotlin/com/projectcitybuild/features/teleporthistory/commands/BackCommand.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/teleporthistory/commands/BackCommand.kt
@@ -1,7 +1,7 @@
 package com.projectcitybuild.features.teleporthistory.commands
 
 import com.projectcitybuild.core.InvalidCommandArgumentsException
-import com.projectcitybuild.modules.config.PluginConfig
+import com.projectcitybuild.modules.config.ConfigKeys
 import com.projectcitybuild.entities.SubChannel
 import com.projectcitybuild.entities.Warp
 import com.projectcitybuild.features.teleporthistory.repositories.LastKnownLocationRepositoy
@@ -52,7 +52,7 @@ class BackCommand @Inject constructor(
             PlayerPreWarpEvent(input.sender, input.sender.location)
         )
 
-        val currentServerName = config.get(PluginConfig.SPIGOT_SERVER_NAME)
+        val currentServerName = config.get(ConfigKeys.SPIGOT_SERVER_NAME)
         val isDestinationOnSameServer = currentServerName == lastKnownLocation.location.serverName
         if (isDestinationOnSameServer) {
             val worldName = lastKnownLocation.location.worldName

--- a/src/main/kotlin/com/projectcitybuild/features/teleporthistory/commands/BackCommand.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/teleporthistory/commands/BackCommand.kt
@@ -1,7 +1,7 @@
 package com.projectcitybuild.features.teleporthistory.commands
 
 import com.projectcitybuild.core.InvalidCommandArgumentsException
-import com.projectcitybuild.modules.config.ConfigKeys
+import com.projectcitybuild.modules.config.ConfigKey
 import com.projectcitybuild.entities.SubChannel
 import com.projectcitybuild.entities.Warp
 import com.projectcitybuild.features.teleporthistory.repositories.LastKnownLocationRepositoy
@@ -52,7 +52,7 @@ class BackCommand @Inject constructor(
             PlayerPreWarpEvent(input.sender, input.sender.location)
         )
 
-        val currentServerName = config.get(ConfigKeys.SPIGOT_SERVER_NAME)
+        val currentServerName = config.get(ConfigKey.SPIGOT_SERVER_NAME)
         val isDestinationOnSameServer = currentServerName == lastKnownLocation.location.serverName
         if (isDestinationOnSameServer) {
             val worldName = lastKnownLocation.location.worldName

--- a/src/main/kotlin/com/projectcitybuild/features/teleporthistory/commands/BackCommand.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/teleporthistory/commands/BackCommand.kt
@@ -1,7 +1,7 @@
 package com.projectcitybuild.features.teleporthistory.commands
 
 import com.projectcitybuild.core.InvalidCommandArgumentsException
-import com.projectcitybuild.entities.PluginConfig
+import com.projectcitybuild.modules.config.PluginConfig
 import com.projectcitybuild.entities.SubChannel
 import com.projectcitybuild.entities.Warp
 import com.projectcitybuild.features.teleporthistory.repositories.LastKnownLocationRepositoy

--- a/src/main/kotlin/com/projectcitybuild/features/teleporthistory/listeners/PlayerSummonListener.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/teleporthistory/listeners/PlayerSummonListener.kt
@@ -2,7 +2,7 @@ package com.projectcitybuild.features.teleporthistory.listeners
 
 import com.projectcitybuild.core.SpigotListener
 import com.projectcitybuild.entities.CrossServerLocation
-import com.projectcitybuild.entities.PluginConfig
+import com.projectcitybuild.modules.config.PluginConfig
 import com.projectcitybuild.features.teleporthistory.repositories.LastKnownLocationRepositoy
 import com.projectcitybuild.features.teleporting.events.PlayerPreSummonEvent
 import com.projectcitybuild.modules.config.PlatformConfig

--- a/src/main/kotlin/com/projectcitybuild/features/teleporthistory/listeners/PlayerSummonListener.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/teleporthistory/listeners/PlayerSummonListener.kt
@@ -2,7 +2,7 @@ package com.projectcitybuild.features.teleporthistory.listeners
 
 import com.projectcitybuild.core.SpigotListener
 import com.projectcitybuild.entities.CrossServerLocation
-import com.projectcitybuild.modules.config.ConfigKeys
+import com.projectcitybuild.modules.config.ConfigKey
 import com.projectcitybuild.features.teleporthistory.repositories.LastKnownLocationRepositoy
 import com.projectcitybuild.features.teleporting.events.PlayerPreSummonEvent
 import com.projectcitybuild.modules.config.PlatformConfig
@@ -19,7 +19,7 @@ class PlayerSummonListener @Inject constructor(
         lastKnownLocationRepository.set(
             playerUUID = event.summonedPlayer.uniqueId,
             location = CrossServerLocation.fromLocation(
-                serverName = config.get(ConfigKeys.SPIGOT_SERVER_NAME),
+                serverName = config.get(ConfigKey.SPIGOT_SERVER_NAME),
                 location = event.currentLocation,
             ),
         )

--- a/src/main/kotlin/com/projectcitybuild/features/teleporthistory/listeners/PlayerSummonListener.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/teleporthistory/listeners/PlayerSummonListener.kt
@@ -2,7 +2,7 @@ package com.projectcitybuild.features.teleporthistory.listeners
 
 import com.projectcitybuild.core.SpigotListener
 import com.projectcitybuild.entities.CrossServerLocation
-import com.projectcitybuild.modules.config.PluginConfig
+import com.projectcitybuild.modules.config.ConfigKeys
 import com.projectcitybuild.features.teleporthistory.repositories.LastKnownLocationRepositoy
 import com.projectcitybuild.features.teleporting.events.PlayerPreSummonEvent
 import com.projectcitybuild.modules.config.PlatformConfig
@@ -19,7 +19,7 @@ class PlayerSummonListener @Inject constructor(
         lastKnownLocationRepository.set(
             playerUUID = event.summonedPlayer.uniqueId,
             location = CrossServerLocation.fromLocation(
-                serverName = config.get(PluginConfig.SPIGOT_SERVER_NAME),
+                serverName = config.get(ConfigKeys.SPIGOT_SERVER_NAME),
                 location = event.currentLocation,
             ),
         )

--- a/src/main/kotlin/com/projectcitybuild/features/teleporthistory/listeners/PlayerTeleportListener.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/teleporthistory/listeners/PlayerTeleportListener.kt
@@ -2,7 +2,7 @@ package com.projectcitybuild.features.teleporthistory.listeners
 
 import com.projectcitybuild.core.SpigotListener
 import com.projectcitybuild.entities.CrossServerLocation
-import com.projectcitybuild.modules.config.ConfigKeys
+import com.projectcitybuild.modules.config.ConfigKey
 import com.projectcitybuild.features.teleporthistory.repositories.LastKnownLocationRepositoy
 import com.projectcitybuild.features.teleporting.events.PlayerPreTeleportEvent
 import com.projectcitybuild.modules.config.PlatformConfig
@@ -19,7 +19,7 @@ class PlayerTeleportListener @Inject constructor(
         lastKnownLocationRepository.set(
             playerUUID = event.player.uniqueId,
             location = CrossServerLocation.fromLocation(
-                serverName = config.get(ConfigKeys.SPIGOT_SERVER_NAME),
+                serverName = config.get(ConfigKey.SPIGOT_SERVER_NAME),
                 location = event.currentLocation,
             )
         )

--- a/src/main/kotlin/com/projectcitybuild/features/teleporthistory/listeners/PlayerTeleportListener.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/teleporthistory/listeners/PlayerTeleportListener.kt
@@ -2,7 +2,7 @@ package com.projectcitybuild.features.teleporthistory.listeners
 
 import com.projectcitybuild.core.SpigotListener
 import com.projectcitybuild.entities.CrossServerLocation
-import com.projectcitybuild.entities.PluginConfig
+import com.projectcitybuild.modules.config.PluginConfig
 import com.projectcitybuild.features.teleporthistory.repositories.LastKnownLocationRepositoy
 import com.projectcitybuild.features.teleporting.events.PlayerPreTeleportEvent
 import com.projectcitybuild.modules.config.PlatformConfig

--- a/src/main/kotlin/com/projectcitybuild/features/teleporthistory/listeners/PlayerTeleportListener.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/teleporthistory/listeners/PlayerTeleportListener.kt
@@ -2,7 +2,7 @@ package com.projectcitybuild.features.teleporthistory.listeners
 
 import com.projectcitybuild.core.SpigotListener
 import com.projectcitybuild.entities.CrossServerLocation
-import com.projectcitybuild.modules.config.PluginConfig
+import com.projectcitybuild.modules.config.ConfigKeys
 import com.projectcitybuild.features.teleporthistory.repositories.LastKnownLocationRepositoy
 import com.projectcitybuild.features.teleporting.events.PlayerPreTeleportEvent
 import com.projectcitybuild.modules.config.PlatformConfig
@@ -19,7 +19,7 @@ class PlayerTeleportListener @Inject constructor(
         lastKnownLocationRepository.set(
             playerUUID = event.player.uniqueId,
             location = CrossServerLocation.fromLocation(
-                serverName = config.get(PluginConfig.SPIGOT_SERVER_NAME),
+                serverName = config.get(ConfigKeys.SPIGOT_SERVER_NAME),
                 location = event.currentLocation,
             )
         )

--- a/src/main/kotlin/com/projectcitybuild/features/teleporthistory/listeners/PlayerWarpListener.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/teleporthistory/listeners/PlayerWarpListener.kt
@@ -2,7 +2,7 @@ package com.projectcitybuild.features.teleporthistory.listeners
 
 import com.projectcitybuild.core.SpigotListener
 import com.projectcitybuild.entities.CrossServerLocation
-import com.projectcitybuild.modules.config.PluginConfig
+import com.projectcitybuild.modules.config.ConfigKeys
 import com.projectcitybuild.features.teleporthistory.repositories.LastKnownLocationRepositoy
 import com.projectcitybuild.features.warps.events.PlayerPreWarpEvent
 import com.projectcitybuild.modules.config.PlatformConfig
@@ -19,7 +19,7 @@ class PlayerWarpListener @Inject constructor(
         lastKnownLocationRepository.set(
             playerUUID = event.player.uniqueId,
             location = CrossServerLocation.fromLocation(
-                serverName = config.get(PluginConfig.SPIGOT_SERVER_NAME),
+                serverName = config.get(ConfigKeys.SPIGOT_SERVER_NAME),
                 location = event.currentLocation,
             )
         )

--- a/src/main/kotlin/com/projectcitybuild/features/teleporthistory/listeners/PlayerWarpListener.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/teleporthistory/listeners/PlayerWarpListener.kt
@@ -2,7 +2,7 @@ package com.projectcitybuild.features.teleporthistory.listeners
 
 import com.projectcitybuild.core.SpigotListener
 import com.projectcitybuild.entities.CrossServerLocation
-import com.projectcitybuild.modules.config.ConfigKeys
+import com.projectcitybuild.modules.config.ConfigKey
 import com.projectcitybuild.features.teleporthistory.repositories.LastKnownLocationRepositoy
 import com.projectcitybuild.features.warps.events.PlayerPreWarpEvent
 import com.projectcitybuild.modules.config.PlatformConfig
@@ -19,7 +19,7 @@ class PlayerWarpListener @Inject constructor(
         lastKnownLocationRepository.set(
             playerUUID = event.player.uniqueId,
             location = CrossServerLocation.fromLocation(
-                serverName = config.get(ConfigKeys.SPIGOT_SERVER_NAME),
+                serverName = config.get(ConfigKey.SPIGOT_SERVER_NAME),
                 location = event.currentLocation,
             )
         )

--- a/src/main/kotlin/com/projectcitybuild/features/teleporthistory/listeners/PlayerWarpListener.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/teleporthistory/listeners/PlayerWarpListener.kt
@@ -2,7 +2,7 @@ package com.projectcitybuild.features.teleporthistory.listeners
 
 import com.projectcitybuild.core.SpigotListener
 import com.projectcitybuild.entities.CrossServerLocation
-import com.projectcitybuild.entities.PluginConfig
+import com.projectcitybuild.modules.config.PluginConfig
 import com.projectcitybuild.features.teleporthistory.repositories.LastKnownLocationRepositoy
 import com.projectcitybuild.features.warps.events.PlayerPreWarpEvent
 import com.projectcitybuild.modules.config.PlatformConfig

--- a/src/main/kotlin/com/projectcitybuild/features/teleporting/commands/TPACommand.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/teleporting/commands/TPACommand.kt
@@ -1,7 +1,7 @@
 package com.projectcitybuild.features.teleporting.commands
 
 import com.projectcitybuild.core.InvalidCommandArgumentsException
-import com.projectcitybuild.modules.config.PluginConfig
+import com.projectcitybuild.modules.config.ConfigKeys
 import com.projectcitybuild.features.teleporting.repositories.TeleportRequestRepository
 import com.projectcitybuild.modules.config.PlatformConfig
 import com.projectcitybuild.modules.nameguesser.NameGuesser
@@ -73,7 +73,7 @@ class TPACommand @Inject constructor(
 
         timer.scheduleOnce(
             identifier = timerIdentifier,
-            delay = config.get(PluginConfig.TP_REQUEST_AUTO_EXPIRE_SECONDS).toLong(),
+            delay = config.get(ConfigKeys.TP_REQUEST_AUTO_EXPIRE_SECONDS).toLong(),
             unit = TimeUnit.SECONDS,
         ) {
             val request = teleportRequestRepository.get(targetPlayer.uniqueId)

--- a/src/main/kotlin/com/projectcitybuild/features/teleporting/commands/TPACommand.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/teleporting/commands/TPACommand.kt
@@ -1,7 +1,7 @@
 package com.projectcitybuild.features.teleporting.commands
 
 import com.projectcitybuild.core.InvalidCommandArgumentsException
-import com.projectcitybuild.modules.config.ConfigKeys
+import com.projectcitybuild.modules.config.ConfigKey
 import com.projectcitybuild.features.teleporting.repositories.TeleportRequestRepository
 import com.projectcitybuild.modules.config.PlatformConfig
 import com.projectcitybuild.modules.nameguesser.NameGuesser
@@ -73,7 +73,7 @@ class TPACommand @Inject constructor(
 
         timer.scheduleOnce(
             identifier = timerIdentifier,
-            delay = config.get(ConfigKeys.TP_REQUEST_AUTO_EXPIRE_SECONDS).toLong(),
+            delay = config.get(ConfigKey.TP_REQUEST_AUTO_EXPIRE_SECONDS).toLong(),
             unit = TimeUnit.SECONDS,
         ) {
             val request = teleportRequestRepository.get(targetPlayer.uniqueId)

--- a/src/main/kotlin/com/projectcitybuild/features/teleporting/commands/TPACommand.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/teleporting/commands/TPACommand.kt
@@ -1,7 +1,7 @@
 package com.projectcitybuild.features.teleporting.commands
 
 import com.projectcitybuild.core.InvalidCommandArgumentsException
-import com.projectcitybuild.entities.PluginConfig
+import com.projectcitybuild.modules.config.PluginConfig
 import com.projectcitybuild.features.teleporting.repositories.TeleportRequestRepository
 import com.projectcitybuild.modules.config.PlatformConfig
 import com.projectcitybuild.modules.nameguesser.NameGuesser

--- a/src/main/kotlin/com/projectcitybuild/features/teleporting/commands/TPAHereCommand.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/teleporting/commands/TPAHereCommand.kt
@@ -1,7 +1,7 @@
 package com.projectcitybuild.features.teleporting.commands
 
 import com.projectcitybuild.core.InvalidCommandArgumentsException
-import com.projectcitybuild.modules.config.PluginConfig
+import com.projectcitybuild.modules.config.ConfigKeys
 import com.projectcitybuild.features.teleporting.repositories.TeleportRequestRepository
 import com.projectcitybuild.modules.config.PlatformConfig
 import com.projectcitybuild.modules.nameguesser.NameGuesser
@@ -73,7 +73,7 @@ class TPAHereCommand @Inject constructor(
 
         timer.scheduleOnce(
             identifier = timerIdentifier,
-            delay = config.get(PluginConfig.TP_REQUEST_AUTO_EXPIRE_SECONDS).toLong(),
+            delay = config.get(ConfigKeys.TP_REQUEST_AUTO_EXPIRE_SECONDS).toLong(),
             unit = TimeUnit.SECONDS,
         ) {
             val request = teleportRequestRepository.get(targetPlayer.uniqueId)

--- a/src/main/kotlin/com/projectcitybuild/features/teleporting/commands/TPAHereCommand.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/teleporting/commands/TPAHereCommand.kt
@@ -1,7 +1,7 @@
 package com.projectcitybuild.features.teleporting.commands
 
 import com.projectcitybuild.core.InvalidCommandArgumentsException
-import com.projectcitybuild.modules.config.ConfigKeys
+import com.projectcitybuild.modules.config.ConfigKey
 import com.projectcitybuild.features.teleporting.repositories.TeleportRequestRepository
 import com.projectcitybuild.modules.config.PlatformConfig
 import com.projectcitybuild.modules.nameguesser.NameGuesser
@@ -73,7 +73,7 @@ class TPAHereCommand @Inject constructor(
 
         timer.scheduleOnce(
             identifier = timerIdentifier,
-            delay = config.get(ConfigKeys.TP_REQUEST_AUTO_EXPIRE_SECONDS).toLong(),
+            delay = config.get(ConfigKey.TP_REQUEST_AUTO_EXPIRE_SECONDS).toLong(),
             unit = TimeUnit.SECONDS,
         ) {
             val request = teleportRequestRepository.get(targetPlayer.uniqueId)

--- a/src/main/kotlin/com/projectcitybuild/features/teleporting/commands/TPAHereCommand.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/teleporting/commands/TPAHereCommand.kt
@@ -1,7 +1,7 @@
 package com.projectcitybuild.features.teleporting.commands
 
 import com.projectcitybuild.core.InvalidCommandArgumentsException
-import com.projectcitybuild.entities.PluginConfig
+import com.projectcitybuild.modules.config.PluginConfig
 import com.projectcitybuild.features.teleporting.repositories.TeleportRequestRepository
 import com.projectcitybuild.modules.config.PlatformConfig
 import com.projectcitybuild.modules.nameguesser.NameGuesser

--- a/src/main/kotlin/com/projectcitybuild/features/teleporting/listeners/TeleportOnJoinListener.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/teleporting/listeners/TeleportOnJoinListener.kt
@@ -1,7 +1,7 @@
 package com.projectcitybuild.features.teleporting.listeners
 
 import com.projectcitybuild.core.SpigotListener
-import com.projectcitybuild.modules.config.ConfigKeys
+import com.projectcitybuild.modules.config.ConfigKey
 import com.projectcitybuild.entities.TeleportType
 import com.projectcitybuild.features.teleporting.repositories.QueuedTeleportRepository
 import com.projectcitybuild.modules.config.PlatformConfig
@@ -21,7 +21,7 @@ class TeleportOnJoinListener @Inject constructor(
     @EventHandler(priority = EventPriority.HIGHEST)
     fun onPlayerJoin(event: PlayerSpawnLocationEvent) {
         val playerUUID = event.player.uniqueId
-        val serverName = config.get(ConfigKeys.SPIGOT_SERVER_NAME)
+        val serverName = config.get(ConfigKey.SPIGOT_SERVER_NAME)
 
         val queuedTeleport = queuedTeleportRepository.get(playerUUID)
         if (queuedTeleport == null) {

--- a/src/main/kotlin/com/projectcitybuild/features/teleporting/listeners/TeleportOnJoinListener.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/teleporting/listeners/TeleportOnJoinListener.kt
@@ -1,7 +1,7 @@
 package com.projectcitybuild.features.teleporting.listeners
 
 import com.projectcitybuild.core.SpigotListener
-import com.projectcitybuild.entities.PluginConfig
+import com.projectcitybuild.modules.config.PluginConfig
 import com.projectcitybuild.entities.TeleportType
 import com.projectcitybuild.features.teleporting.repositories.QueuedTeleportRepository
 import com.projectcitybuild.modules.config.PlatformConfig

--- a/src/main/kotlin/com/projectcitybuild/features/teleporting/listeners/TeleportOnJoinListener.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/teleporting/listeners/TeleportOnJoinListener.kt
@@ -1,7 +1,7 @@
 package com.projectcitybuild.features.teleporting.listeners
 
 import com.projectcitybuild.core.SpigotListener
-import com.projectcitybuild.modules.config.PluginConfig
+import com.projectcitybuild.modules.config.ConfigKeys
 import com.projectcitybuild.entities.TeleportType
 import com.projectcitybuild.features.teleporting.repositories.QueuedTeleportRepository
 import com.projectcitybuild.modules.config.PlatformConfig
@@ -21,7 +21,7 @@ class TeleportOnJoinListener @Inject constructor(
     @EventHandler(priority = EventPriority.HIGHEST)
     fun onPlayerJoin(event: PlayerSpawnLocationEvent) {
         val playerUUID = event.player.uniqueId
-        val serverName = config.get(PluginConfig.SPIGOT_SERVER_NAME)
+        val serverName = config.get(ConfigKeys.SPIGOT_SERVER_NAME)
 
         val queuedTeleport = queuedTeleportRepository.get(playerUUID)
         if (queuedTeleport == null) {

--- a/src/main/kotlin/com/projectcitybuild/features/warps/adapters/dynmap/DynmapMarkerAdapter.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/warps/adapters/dynmap/DynmapMarkerAdapter.kt
@@ -1,7 +1,7 @@
 package com.projectcitybuild.features.warps.adapters.dynmap
 
 import com.projectcitybuild.core.SpigotListener
-import com.projectcitybuild.entities.PluginConfig
+import com.projectcitybuild.modules.config.PluginConfig
 import com.projectcitybuild.features.warps.events.WarpCreateEvent
 import com.projectcitybuild.features.warps.events.WarpDeleteEvent
 import com.projectcitybuild.features.warps.repositories.WarpRepository

--- a/src/main/kotlin/com/projectcitybuild/features/warps/adapters/dynmap/DynmapMarkerAdapter.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/warps/adapters/dynmap/DynmapMarkerAdapter.kt
@@ -1,7 +1,7 @@
 package com.projectcitybuild.features.warps.adapters.dynmap
 
 import com.projectcitybuild.core.SpigotListener
-import com.projectcitybuild.modules.config.PluginConfig
+import com.projectcitybuild.modules.config.ConfigKeys
 import com.projectcitybuild.features.warps.events.WarpCreateEvent
 import com.projectcitybuild.features.warps.events.WarpDeleteEvent
 import com.projectcitybuild.features.warps.repositories.WarpRepository
@@ -76,7 +76,7 @@ class DynmapMarkerAdapter @Inject constructor(
             it.deleteMarker()
         }
 
-        val iconName = config.get(PluginConfig.INTEGRATION_DYNMAP_WARP_ICON)
+        val iconName = config.get(ConfigKeys.INTEGRATION_DYNMAP_WARP_ICON)
         val icon = markerAPI.getMarkerIcon(iconName)
             ?: throw DynmapMarkerIconNotFoundException()
 

--- a/src/main/kotlin/com/projectcitybuild/features/warps/adapters/dynmap/DynmapMarkerAdapter.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/warps/adapters/dynmap/DynmapMarkerAdapter.kt
@@ -1,7 +1,7 @@
 package com.projectcitybuild.features.warps.adapters.dynmap
 
 import com.projectcitybuild.core.SpigotListener
-import com.projectcitybuild.modules.config.ConfigKeys
+import com.projectcitybuild.modules.config.ConfigKey
 import com.projectcitybuild.features.warps.events.WarpCreateEvent
 import com.projectcitybuild.features.warps.events.WarpDeleteEvent
 import com.projectcitybuild.features.warps.repositories.WarpRepository
@@ -76,7 +76,7 @@ class DynmapMarkerAdapter @Inject constructor(
             it.deleteMarker()
         }
 
-        val iconName = config.get(ConfigKeys.INTEGRATION_DYNMAP_WARP_ICON)
+        val iconName = config.get(ConfigKey.INTEGRATION_DYNMAP_WARP_ICON)
         val icon = markerAPI.getMarkerIcon(iconName)
             ?: throw DynmapMarkerIconNotFoundException()
 

--- a/src/main/kotlin/com/projectcitybuild/features/warps/commands/SetWarpCommand.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/warps/commands/SetWarpCommand.kt
@@ -3,7 +3,7 @@ package com.projectcitybuild.features.warps.commands
 import com.projectcitybuild.core.InvalidCommandArgumentsException
 import com.projectcitybuild.core.utilities.Failure
 import com.projectcitybuild.entities.CrossServerLocation
-import com.projectcitybuild.entities.PluginConfig
+import com.projectcitybuild.modules.config.PluginConfig
 import com.projectcitybuild.features.warps.usecases.CreateWarpUseCase
 import com.projectcitybuild.modules.config.PlatformConfig
 import com.projectcitybuild.modules.textcomponentbuilder.send

--- a/src/main/kotlin/com/projectcitybuild/features/warps/commands/SetWarpCommand.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/warps/commands/SetWarpCommand.kt
@@ -3,7 +3,7 @@ package com.projectcitybuild.features.warps.commands
 import com.projectcitybuild.core.InvalidCommandArgumentsException
 import com.projectcitybuild.core.utilities.Failure
 import com.projectcitybuild.entities.CrossServerLocation
-import com.projectcitybuild.modules.config.PluginConfig
+import com.projectcitybuild.modules.config.ConfigKeys
 import com.projectcitybuild.features.warps.usecases.CreateWarpUseCase
 import com.projectcitybuild.modules.config.PlatformConfig
 import com.projectcitybuild.modules.textcomponentbuilder.send
@@ -33,7 +33,7 @@ class SetWarpCommand @Inject constructor(
 
         val warpName = input.args.first()
         val location = CrossServerLocation.fromLocation(
-            serverName = config.get(PluginConfig.SPIGOT_SERVER_NAME),
+            serverName = config.get(ConfigKeys.SPIGOT_SERVER_NAME),
             location = player.location,
         )
         val result = createWarpUseCase.createWarp(warpName, location)

--- a/src/main/kotlin/com/projectcitybuild/features/warps/commands/SetWarpCommand.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/warps/commands/SetWarpCommand.kt
@@ -3,7 +3,7 @@ package com.projectcitybuild.features.warps.commands
 import com.projectcitybuild.core.InvalidCommandArgumentsException
 import com.projectcitybuild.core.utilities.Failure
 import com.projectcitybuild.entities.CrossServerLocation
-import com.projectcitybuild.modules.config.ConfigKeys
+import com.projectcitybuild.modules.config.ConfigKey
 import com.projectcitybuild.features.warps.usecases.CreateWarpUseCase
 import com.projectcitybuild.modules.config.PlatformConfig
 import com.projectcitybuild.modules.textcomponentbuilder.send
@@ -33,7 +33,7 @@ class SetWarpCommand @Inject constructor(
 
         val warpName = input.args.first()
         val location = CrossServerLocation.fromLocation(
-            serverName = config.get(ConfigKeys.SPIGOT_SERVER_NAME),
+            serverName = config.get(ConfigKey.SPIGOT_SERVER_NAME),
             location = player.location,
         )
         val result = createWarpUseCase.createWarp(warpName, location)

--- a/src/main/kotlin/com/projectcitybuild/features/warps/commands/WarpCommand.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/warps/commands/WarpCommand.kt
@@ -3,7 +3,7 @@ package com.projectcitybuild.features.warps.commands
 import com.projectcitybuild.core.InvalidCommandArgumentsException
 import com.projectcitybuild.core.utilities.Failure
 import com.projectcitybuild.core.utilities.Success
-import com.projectcitybuild.modules.config.ConfigKeys
+import com.projectcitybuild.modules.config.ConfigKey
 import com.projectcitybuild.features.warps.repositories.WarpRepository
 import com.projectcitybuild.features.warps.usecases.WarpUseCase
 import com.projectcitybuild.modules.config.PlatformConfig
@@ -36,7 +36,7 @@ class WarpCommand @Inject constructor(
         val targetWarpName = input.args.first()
         val result = warpUseCase.warp(
             targetWarpName,
-            config.get(ConfigKeys.SPIGOT_SERVER_NAME),
+            config.get(ConfigKey.SPIGOT_SERVER_NAME),
             input.sender
         )
 

--- a/src/main/kotlin/com/projectcitybuild/features/warps/commands/WarpCommand.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/warps/commands/WarpCommand.kt
@@ -3,7 +3,7 @@ package com.projectcitybuild.features.warps.commands
 import com.projectcitybuild.core.InvalidCommandArgumentsException
 import com.projectcitybuild.core.utilities.Failure
 import com.projectcitybuild.core.utilities.Success
-import com.projectcitybuild.modules.config.PluginConfig
+import com.projectcitybuild.modules.config.ConfigKeys
 import com.projectcitybuild.features.warps.repositories.WarpRepository
 import com.projectcitybuild.features.warps.usecases.WarpUseCase
 import com.projectcitybuild.modules.config.PlatformConfig
@@ -36,7 +36,7 @@ class WarpCommand @Inject constructor(
         val targetWarpName = input.args.first()
         val result = warpUseCase.warp(
             targetWarpName,
-            config.get(PluginConfig.SPIGOT_SERVER_NAME),
+            config.get(ConfigKeys.SPIGOT_SERVER_NAME),
             input.sender
         )
 

--- a/src/main/kotlin/com/projectcitybuild/features/warps/commands/WarpCommand.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/warps/commands/WarpCommand.kt
@@ -3,7 +3,7 @@ package com.projectcitybuild.features.warps.commands
 import com.projectcitybuild.core.InvalidCommandArgumentsException
 import com.projectcitybuild.core.utilities.Failure
 import com.projectcitybuild.core.utilities.Success
-import com.projectcitybuild.entities.PluginConfig
+import com.projectcitybuild.modules.config.PluginConfig
 import com.projectcitybuild.features.warps.repositories.WarpRepository
 import com.projectcitybuild.features.warps.usecases.WarpUseCase
 import com.projectcitybuild.modules.config.PlatformConfig

--- a/src/main/kotlin/com/projectcitybuild/features/warps/listeners/WarpOnJoinListener.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/warps/listeners/WarpOnJoinListener.kt
@@ -1,7 +1,7 @@
 package com.projectcitybuild.features.warps.listeners
 
 import com.projectcitybuild.core.SpigotListener
-import com.projectcitybuild.entities.PluginConfig
+import com.projectcitybuild.modules.config.PluginConfig
 import com.projectcitybuild.features.warps.repositories.QueuedWarpRepository
 import com.projectcitybuild.modules.config.PlatformConfig
 import com.projectcitybuild.modules.logger.PlatformLogger

--- a/src/main/kotlin/com/projectcitybuild/features/warps/listeners/WarpOnJoinListener.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/warps/listeners/WarpOnJoinListener.kt
@@ -1,7 +1,7 @@
 package com.projectcitybuild.features.warps.listeners
 
 import com.projectcitybuild.core.SpigotListener
-import com.projectcitybuild.modules.config.ConfigKeys
+import com.projectcitybuild.modules.config.ConfigKey
 import com.projectcitybuild.features.warps.repositories.QueuedWarpRepository
 import com.projectcitybuild.modules.config.PlatformConfig
 import com.projectcitybuild.modules.logger.PlatformLogger
@@ -21,7 +21,7 @@ class WarpOnJoinListener @Inject constructor(
     @EventHandler(priority = EventPriority.HIGHEST)
     fun onPlayerJoin(event: PlayerSpawnLocationEvent) {
         val playerUUID = event.player.uniqueId
-        val serverName = config.get(ConfigKeys.SPIGOT_SERVER_NAME)
+        val serverName = config.get(ConfigKey.SPIGOT_SERVER_NAME)
 
         val queuedWarp = queuedWarpRepository.get(playerUUID)
         if (queuedWarp == null) {

--- a/src/main/kotlin/com/projectcitybuild/features/warps/listeners/WarpOnJoinListener.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/warps/listeners/WarpOnJoinListener.kt
@@ -1,7 +1,7 @@
 package com.projectcitybuild.features.warps.listeners
 
 import com.projectcitybuild.core.SpigotListener
-import com.projectcitybuild.modules.config.PluginConfig
+import com.projectcitybuild.modules.config.ConfigKeys
 import com.projectcitybuild.features.warps.repositories.QueuedWarpRepository
 import com.projectcitybuild.modules.config.PlatformConfig
 import com.projectcitybuild.modules.logger.PlatformLogger
@@ -21,7 +21,7 @@ class WarpOnJoinListener @Inject constructor(
     @EventHandler(priority = EventPriority.HIGHEST)
     fun onPlayerJoin(event: PlayerSpawnLocationEvent) {
         val playerUUID = event.player.uniqueId
-        val serverName = config.get(PluginConfig.SPIGOT_SERVER_NAME)
+        val serverName = config.get(ConfigKeys.SPIGOT_SERVER_NAME)
 
         val queuedWarp = queuedWarpRepository.get(playerUUID)
         if (queuedWarp == null) {

--- a/src/main/kotlin/com/projectcitybuild/features/warps/usecases/WarpListUseCase.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/warps/usecases/WarpListUseCase.kt
@@ -1,6 +1,6 @@
 package com.projectcitybuild.features.warps.usecases.warplist
 
-import com.projectcitybuild.modules.config.ConfigKeys
+import com.projectcitybuild.modules.config.ConfigKey
 import com.projectcitybuild.features.warps.repositories.WarpRepository
 import com.projectcitybuild.modules.config.PlatformConfig
 import javax.inject.Inject
@@ -19,7 +19,7 @@ class WarpListUseCase @Inject constructor(
     )
 
     fun getList(page: Int = 1): WarpList? {
-        val warpsPerPage = config.get(ConfigKeys.WARPS_PER_PAGE)
+        val warpsPerPage = config.get(ConfigKey.WARPS_PER_PAGE)
         val availableWarps = warpRepository.names()
         val totalWarpPages = ceil((availableWarps.size.toDouble() / warpsPerPage.toDouble())).toInt()
 

--- a/src/main/kotlin/com/projectcitybuild/features/warps/usecases/WarpListUseCase.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/warps/usecases/WarpListUseCase.kt
@@ -1,6 +1,6 @@
 package com.projectcitybuild.features.warps.usecases.warplist
 
-import com.projectcitybuild.entities.PluginConfig
+import com.projectcitybuild.modules.config.PluginConfig
 import com.projectcitybuild.features.warps.repositories.WarpRepository
 import com.projectcitybuild.modules.config.PlatformConfig
 import javax.inject.Inject

--- a/src/main/kotlin/com/projectcitybuild/features/warps/usecases/WarpListUseCase.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/warps/usecases/WarpListUseCase.kt
@@ -1,6 +1,6 @@
 package com.projectcitybuild.features.warps.usecases.warplist
 
-import com.projectcitybuild.modules.config.PluginConfig
+import com.projectcitybuild.modules.config.ConfigKeys
 import com.projectcitybuild.features.warps.repositories.WarpRepository
 import com.projectcitybuild.modules.config.PlatformConfig
 import javax.inject.Inject
@@ -19,7 +19,7 @@ class WarpListUseCase @Inject constructor(
     )
 
     fun getList(page: Int = 1): WarpList? {
-        val warpsPerPage = config.get(PluginConfig.WARPS_PER_PAGE)
+        val warpsPerPage = config.get(ConfigKeys.WARPS_PER_PAGE)
         val availableWarps = warpRepository.names()
         val totalWarpPages = ceil((availableWarps.size.toDouble() / warpsPerPage.toDouble())).toInt()
 

--- a/src/main/kotlin/com/projectcitybuild/modules/config/ConfigKey.kt
+++ b/src/main/kotlin/com/projectcitybuild/modules/config/ConfigKey.kt
@@ -1,6 +1,6 @@
 package com.projectcitybuild.modules.config
 
-sealed class ConfigKeys {
+sealed class ConfigKey {
 
     data class ConfigPath<T>(val key: String, val defaultValue: T)
 
@@ -9,6 +9,7 @@ sealed class ConfigKeys {
             return ConfigPath(this, defaultValue)
         }
 
+        val API_ENABLED = "api.enabled" defaultTo false
         val API_KEY = "api.key" defaultTo "FILL_THIS_IN"
         val API_BASE_URL = "api.base_url" defaultTo "https://projectcitybuild.com/api/"
         val API_IS_LOGGING_ENABLED = "api.is_logging_enabled" defaultTo false

--- a/src/main/kotlin/com/projectcitybuild/modules/config/ConfigKeys.kt
+++ b/src/main/kotlin/com/projectcitybuild/modules/config/ConfigKeys.kt
@@ -1,10 +1,10 @@
 package com.projectcitybuild.modules.config
 
-sealed class PluginConfig {
+sealed class ConfigKeys {
 
     data class ConfigPath<T>(val key: String, val defaultValue: T)
 
-    companion object Keys {
+    companion object {
         private infix fun <T> String.defaultTo(defaultValue: T): ConfigPath<T> {
             return ConfigPath(this, defaultValue)
         }

--- a/src/main/kotlin/com/projectcitybuild/modules/config/PlatformConfig.kt
+++ b/src/main/kotlin/com/projectcitybuild/modules/config/PlatformConfig.kt
@@ -1,10 +1,8 @@
 package com.projectcitybuild.modules.config
 
-import com.projectcitybuild.modules.config.PluginConfig
-
 interface PlatformConfig {
-    fun <T> get(key: PluginConfig.ConfigPath<T>): T
-    fun <T> set(key: PluginConfig.ConfigPath<T>, value: T)
+    fun <T> get(key: ConfigKeys.ConfigPath<T>): T
+    fun <T> set(key: ConfigKeys.ConfigPath<T>, value: T)
 
     fun get(path: String): Any?
 }

--- a/src/main/kotlin/com/projectcitybuild/modules/config/PlatformConfig.kt
+++ b/src/main/kotlin/com/projectcitybuild/modules/config/PlatformConfig.kt
@@ -1,6 +1,6 @@
 package com.projectcitybuild.modules.config
 
-import com.projectcitybuild.entities.PluginConfig
+import com.projectcitybuild.modules.config.PluginConfig
 
 interface PlatformConfig {
     fun <T> get(key: PluginConfig.ConfigPath<T>): T

--- a/src/main/kotlin/com/projectcitybuild/modules/config/PlatformConfig.kt
+++ b/src/main/kotlin/com/projectcitybuild/modules/config/PlatformConfig.kt
@@ -1,8 +1,8 @@
 package com.projectcitybuild.modules.config
 
 interface PlatformConfig {
-    fun <T> get(key: ConfigKeys.ConfigPath<T>): T
-    fun <T> set(key: ConfigKeys.ConfigPath<T>, value: T)
+    fun <T> get(key: ConfigKey.ConfigPath<T>): T
+    fun <T> set(key: ConfigKey.ConfigPath<T>, value: T)
 
     fun get(path: String): Any?
 }

--- a/src/main/kotlin/com/projectcitybuild/modules/config/PluginConfig.kt
+++ b/src/main/kotlin/com/projectcitybuild/modules/config/PluginConfig.kt
@@ -1,4 +1,4 @@
-package com.projectcitybuild.entities
+package com.projectcitybuild.modules.config
 
 sealed class PluginConfig {
 

--- a/src/main/kotlin/com/projectcitybuild/modules/config/implementations/BungeecordConfig.kt
+++ b/src/main/kotlin/com/projectcitybuild/modules/config/implementations/BungeecordConfig.kt
@@ -1,7 +1,7 @@
 package com.projectcitybuild.modules.config.implementations
 
 import com.google.common.io.ByteStreams
-import com.projectcitybuild.entities.PluginConfig
+import com.projectcitybuild.modules.config.PluginConfig
 import com.projectcitybuild.modules.config.PlatformConfig
 import net.md_5.bungee.config.Configuration
 import net.md_5.bungee.config.ConfigurationProvider

--- a/src/main/kotlin/com/projectcitybuild/modules/config/implementations/BungeecordConfig.kt
+++ b/src/main/kotlin/com/projectcitybuild/modules/config/implementations/BungeecordConfig.kt
@@ -1,7 +1,7 @@
 package com.projectcitybuild.modules.config.implementations
 
 import com.google.common.io.ByteStreams
-import com.projectcitybuild.modules.config.PluginConfig
+import com.projectcitybuild.modules.config.ConfigKeys
 import com.projectcitybuild.modules.config.PlatformConfig
 import net.md_5.bungee.config.Configuration
 import net.md_5.bungee.config.ConfigurationProvider
@@ -32,34 +32,34 @@ class BungeecordConfig(
 
     private fun generateDefaultConfig(config: Configuration) {
         arrayOf(
-            PluginConfig.API_KEY,
-            PluginConfig.API_BASE_URL,
-            PluginConfig.API_IS_LOGGING_ENABLED,
-            PluginConfig.WARPS_PER_PAGE,
-            PluginConfig.TP_REQUEST_AUTO_EXPIRE_SECONDS,
-            PluginConfig.DB_HOSTNAME,
-            PluginConfig.DB_PORT,
-            PluginConfig.DB_NAME,
-            PluginConfig.DB_USERNAME,
-            PluginConfig.DB_PASSWORD,
-            PluginConfig.ERROR_REPORTING_SENTRY_ENABLED,
-            PluginConfig.ERROR_REPORTING_SENTRY_DSN,
-            PluginConfig.GROUPS_APPEARANCE_ADMIN_DISPLAY_NAME,
-            PluginConfig.GROUPS_APPEARANCE_ADMIN_HOVER_NAME,
-            PluginConfig.GROUPS_APPEARANCE_SOP_DISPLAY_NAME,
-            PluginConfig.GROUPS_APPEARANCE_SOP_HOVER_NAME,
-            PluginConfig.GROUPS_APPEARANCE_OP_DISPLAY_NAME,
-            PluginConfig.GROUPS_APPEARANCE_OP_HOVER_NAME,
-            PluginConfig.GROUPS_APPEARANCE_MODERATOR_DISPLAY_NAME,
-            PluginConfig.GROUPS_APPEARANCE_MODERATOR_HOVER_NAME,
-            PluginConfig.GROUPS_APPEARANCE_TRUSTEDPLUS_HOVER_NAME,
-            PluginConfig.GROUPS_APPEARANCE_TRUSTED_HOVER_NAME,
-            PluginConfig.GROUPS_APPEARANCE_DONOR_HOVER_NAME,
-            PluginConfig.GROUPS_APPEARANCE_ARCHITECT_HOVER_NAME,
-            PluginConfig.GROUPS_APPEARANCE_ENGINEER_HOVER_NAME,
-            PluginConfig.GROUPS_APPEARANCE_PLANNER_HOVER_NAME,
-            PluginConfig.GROUPS_APPEARANCE_BUILDER_HOVER_NAME,
-            PluginConfig.GROUPS_APPEARANCE_INTERN_HOVER_NAME,
+            ConfigKeys.API_KEY,
+            ConfigKeys.API_BASE_URL,
+            ConfigKeys.API_IS_LOGGING_ENABLED,
+            ConfigKeys.WARPS_PER_PAGE,
+            ConfigKeys.TP_REQUEST_AUTO_EXPIRE_SECONDS,
+            ConfigKeys.DB_HOSTNAME,
+            ConfigKeys.DB_PORT,
+            ConfigKeys.DB_NAME,
+            ConfigKeys.DB_USERNAME,
+            ConfigKeys.DB_PASSWORD,
+            ConfigKeys.ERROR_REPORTING_SENTRY_ENABLED,
+            ConfigKeys.ERROR_REPORTING_SENTRY_DSN,
+            ConfigKeys.GROUPS_APPEARANCE_ADMIN_DISPLAY_NAME,
+            ConfigKeys.GROUPS_APPEARANCE_ADMIN_HOVER_NAME,
+            ConfigKeys.GROUPS_APPEARANCE_SOP_DISPLAY_NAME,
+            ConfigKeys.GROUPS_APPEARANCE_SOP_HOVER_NAME,
+            ConfigKeys.GROUPS_APPEARANCE_OP_DISPLAY_NAME,
+            ConfigKeys.GROUPS_APPEARANCE_OP_HOVER_NAME,
+            ConfigKeys.GROUPS_APPEARANCE_MODERATOR_DISPLAY_NAME,
+            ConfigKeys.GROUPS_APPEARANCE_MODERATOR_HOVER_NAME,
+            ConfigKeys.GROUPS_APPEARANCE_TRUSTEDPLUS_HOVER_NAME,
+            ConfigKeys.GROUPS_APPEARANCE_TRUSTED_HOVER_NAME,
+            ConfigKeys.GROUPS_APPEARANCE_DONOR_HOVER_NAME,
+            ConfigKeys.GROUPS_APPEARANCE_ARCHITECT_HOVER_NAME,
+            ConfigKeys.GROUPS_APPEARANCE_ENGINEER_HOVER_NAME,
+            ConfigKeys.GROUPS_APPEARANCE_PLANNER_HOVER_NAME,
+            ConfigKeys.GROUPS_APPEARANCE_BUILDER_HOVER_NAME,
+            ConfigKeys.GROUPS_APPEARANCE_INTERN_HOVER_NAME,
         ).forEach { key ->
             if (config.get(key.key) == null)
                 config.set(key.key, key.defaultValue)
@@ -68,7 +68,7 @@ class BungeecordConfig(
     }
 
     @Suppress("UNCHECKED_CAST")
-    override fun <T> get(key: PluginConfig.ConfigPath<T>): T {
+    override fun <T> get(key: ConfigKeys.ConfigPath<T>): T {
         val config = config
         return config.get(key.key) as? T ?: key.defaultValue
     }
@@ -78,7 +78,7 @@ class BungeecordConfig(
         return config.get(path)
     }
 
-    override fun <T> set(key: PluginConfig.ConfigPath<T>, value: T) {
+    override fun <T> set(key: ConfigKeys.ConfigPath<T>, value: T) {
         val config = config
 
         config.set(key.key, value)

--- a/src/main/kotlin/com/projectcitybuild/modules/config/implementations/BungeecordConfig.kt
+++ b/src/main/kotlin/com/projectcitybuild/modules/config/implementations/BungeecordConfig.kt
@@ -1,7 +1,7 @@
 package com.projectcitybuild.modules.config.implementations
 
 import com.google.common.io.ByteStreams
-import com.projectcitybuild.modules.config.ConfigKeys
+import com.projectcitybuild.modules.config.ConfigKey
 import com.projectcitybuild.modules.config.PlatformConfig
 import net.md_5.bungee.config.Configuration
 import net.md_5.bungee.config.ConfigurationProvider
@@ -32,34 +32,35 @@ class BungeecordConfig(
 
     private fun generateDefaultConfig(config: Configuration) {
         arrayOf(
-            ConfigKeys.API_KEY,
-            ConfigKeys.API_BASE_URL,
-            ConfigKeys.API_IS_LOGGING_ENABLED,
-            ConfigKeys.WARPS_PER_PAGE,
-            ConfigKeys.TP_REQUEST_AUTO_EXPIRE_SECONDS,
-            ConfigKeys.DB_HOSTNAME,
-            ConfigKeys.DB_PORT,
-            ConfigKeys.DB_NAME,
-            ConfigKeys.DB_USERNAME,
-            ConfigKeys.DB_PASSWORD,
-            ConfigKeys.ERROR_REPORTING_SENTRY_ENABLED,
-            ConfigKeys.ERROR_REPORTING_SENTRY_DSN,
-            ConfigKeys.GROUPS_APPEARANCE_ADMIN_DISPLAY_NAME,
-            ConfigKeys.GROUPS_APPEARANCE_ADMIN_HOVER_NAME,
-            ConfigKeys.GROUPS_APPEARANCE_SOP_DISPLAY_NAME,
-            ConfigKeys.GROUPS_APPEARANCE_SOP_HOVER_NAME,
-            ConfigKeys.GROUPS_APPEARANCE_OP_DISPLAY_NAME,
-            ConfigKeys.GROUPS_APPEARANCE_OP_HOVER_NAME,
-            ConfigKeys.GROUPS_APPEARANCE_MODERATOR_DISPLAY_NAME,
-            ConfigKeys.GROUPS_APPEARANCE_MODERATOR_HOVER_NAME,
-            ConfigKeys.GROUPS_APPEARANCE_TRUSTEDPLUS_HOVER_NAME,
-            ConfigKeys.GROUPS_APPEARANCE_TRUSTED_HOVER_NAME,
-            ConfigKeys.GROUPS_APPEARANCE_DONOR_HOVER_NAME,
-            ConfigKeys.GROUPS_APPEARANCE_ARCHITECT_HOVER_NAME,
-            ConfigKeys.GROUPS_APPEARANCE_ENGINEER_HOVER_NAME,
-            ConfigKeys.GROUPS_APPEARANCE_PLANNER_HOVER_NAME,
-            ConfigKeys.GROUPS_APPEARANCE_BUILDER_HOVER_NAME,
-            ConfigKeys.GROUPS_APPEARANCE_INTERN_HOVER_NAME,
+            ConfigKey.API_ENABLED,
+            ConfigKey.API_KEY,
+            ConfigKey.API_BASE_URL,
+            ConfigKey.API_IS_LOGGING_ENABLED,
+            ConfigKey.WARPS_PER_PAGE,
+            ConfigKey.TP_REQUEST_AUTO_EXPIRE_SECONDS,
+            ConfigKey.DB_HOSTNAME,
+            ConfigKey.DB_PORT,
+            ConfigKey.DB_NAME,
+            ConfigKey.DB_USERNAME,
+            ConfigKey.DB_PASSWORD,
+            ConfigKey.ERROR_REPORTING_SENTRY_ENABLED,
+            ConfigKey.ERROR_REPORTING_SENTRY_DSN,
+            ConfigKey.GROUPS_APPEARANCE_ADMIN_DISPLAY_NAME,
+            ConfigKey.GROUPS_APPEARANCE_ADMIN_HOVER_NAME,
+            ConfigKey.GROUPS_APPEARANCE_SOP_DISPLAY_NAME,
+            ConfigKey.GROUPS_APPEARANCE_SOP_HOVER_NAME,
+            ConfigKey.GROUPS_APPEARANCE_OP_DISPLAY_NAME,
+            ConfigKey.GROUPS_APPEARANCE_OP_HOVER_NAME,
+            ConfigKey.GROUPS_APPEARANCE_MODERATOR_DISPLAY_NAME,
+            ConfigKey.GROUPS_APPEARANCE_MODERATOR_HOVER_NAME,
+            ConfigKey.GROUPS_APPEARANCE_TRUSTEDPLUS_HOVER_NAME,
+            ConfigKey.GROUPS_APPEARANCE_TRUSTED_HOVER_NAME,
+            ConfigKey.GROUPS_APPEARANCE_DONOR_HOVER_NAME,
+            ConfigKey.GROUPS_APPEARANCE_ARCHITECT_HOVER_NAME,
+            ConfigKey.GROUPS_APPEARANCE_ENGINEER_HOVER_NAME,
+            ConfigKey.GROUPS_APPEARANCE_PLANNER_HOVER_NAME,
+            ConfigKey.GROUPS_APPEARANCE_BUILDER_HOVER_NAME,
+            ConfigKey.GROUPS_APPEARANCE_INTERN_HOVER_NAME,
         ).forEach { key ->
             if (config.get(key.key) == null)
                 config.set(key.key, key.defaultValue)
@@ -68,7 +69,7 @@ class BungeecordConfig(
     }
 
     @Suppress("UNCHECKED_CAST")
-    override fun <T> get(key: ConfigKeys.ConfigPath<T>): T {
+    override fun <T> get(key: ConfigKey.ConfigPath<T>): T {
         val config = config
         return config.get(key.key) as? T ?: key.defaultValue
     }
@@ -78,7 +79,7 @@ class BungeecordConfig(
         return config.get(path)
     }
 
-    override fun <T> set(key: ConfigKeys.ConfigPath<T>, value: T) {
+    override fun <T> set(key: ConfigKey.ConfigPath<T>, value: T) {
         val config = config
 
         config.set(key.key, value)

--- a/src/main/kotlin/com/projectcitybuild/modules/config/implementations/SpigotConfig.kt
+++ b/src/main/kotlin/com/projectcitybuild/modules/config/implementations/SpigotConfig.kt
@@ -1,6 +1,6 @@
 package com.projectcitybuild.modules.config.implementations
 
-import com.projectcitybuild.entities.PluginConfig
+import com.projectcitybuild.modules.config.PluginConfig
 import com.projectcitybuild.modules.config.PlatformConfig
 import dagger.Reusable
 import org.bukkit.configuration.file.FileConfiguration

--- a/src/main/kotlin/com/projectcitybuild/modules/config/implementations/SpigotConfig.kt
+++ b/src/main/kotlin/com/projectcitybuild/modules/config/implementations/SpigotConfig.kt
@@ -1,6 +1,6 @@
 package com.projectcitybuild.modules.config.implementations
 
-import com.projectcitybuild.modules.config.ConfigKeys
+import com.projectcitybuild.modules.config.ConfigKey
 import com.projectcitybuild.modules.config.PlatformConfig
 import dagger.Reusable
 import org.bukkit.configuration.file.FileConfiguration
@@ -18,21 +18,21 @@ class SpigotConfig(
 
     private fun generateDefaultConfig() {
         arrayOf(
-            ConfigKeys.SPIGOT_SERVER_NAME,
-            ConfigKeys.DB_HOSTNAME,
-            ConfigKeys.DB_PORT,
-            ConfigKeys.DB_NAME,
-            ConfigKeys.DB_USERNAME,
-            ConfigKeys.DB_PASSWORD,
-            ConfigKeys.REDIS_HOSTNAME,
-            ConfigKeys.REDIS_PORT,
-            ConfigKeys.REDIS_USERNAME,
-            ConfigKeys.REDIS_PASSWORD,
-            ConfigKeys.ERROR_REPORTING_SENTRY_ENABLED,
-            ConfigKeys.ERROR_REPORTING_SENTRY_DSN,
-            ConfigKeys.SHARED_CACHE_ADAPTER,
-            ConfigKeys.SHARED_CACHE_FILE_RELATIVE_PATH,
-            ConfigKeys.INTEGRATION_DYNMAP_WARP_ICON,
+            ConfigKey.SPIGOT_SERVER_NAME,
+            ConfigKey.DB_HOSTNAME,
+            ConfigKey.DB_PORT,
+            ConfigKey.DB_NAME,
+            ConfigKey.DB_USERNAME,
+            ConfigKey.DB_PASSWORD,
+            ConfigKey.REDIS_HOSTNAME,
+            ConfigKey.REDIS_PORT,
+            ConfigKey.REDIS_USERNAME,
+            ConfigKey.REDIS_PASSWORD,
+            ConfigKey.ERROR_REPORTING_SENTRY_ENABLED,
+            ConfigKey.ERROR_REPORTING_SENTRY_DSN,
+            ConfigKey.SHARED_CACHE_ADAPTER,
+            ConfigKey.SHARED_CACHE_FILE_RELATIVE_PATH,
+            ConfigKey.INTEGRATION_DYNMAP_WARP_ICON,
         ).forEach { key ->
             config.addDefault(key.key, key.defaultValue)
         }
@@ -40,7 +40,7 @@ class SpigotConfig(
         plugin.saveConfig()
     }
 
-    override fun <T> get(key: ConfigKeys.ConfigPath<T>): T {
+    override fun <T> get(key: ConfigKey.ConfigPath<T>): T {
         val value = config.get(key.key) as T
         if (value != null) {
             return value
@@ -52,7 +52,7 @@ class SpigotConfig(
         return config.get(path)
     }
 
-    override fun <T> set(key: ConfigKeys.ConfigPath<T>, value: T) {
+    override fun <T> set(key: ConfigKey.ConfigPath<T>, value: T) {
         return config.set(key.key, value)
     }
 }

--- a/src/main/kotlin/com/projectcitybuild/modules/config/implementations/SpigotConfig.kt
+++ b/src/main/kotlin/com/projectcitybuild/modules/config/implementations/SpigotConfig.kt
@@ -1,6 +1,6 @@
 package com.projectcitybuild.modules.config.implementations
 
-import com.projectcitybuild.modules.config.PluginConfig
+import com.projectcitybuild.modules.config.ConfigKeys
 import com.projectcitybuild.modules.config.PlatformConfig
 import dagger.Reusable
 import org.bukkit.configuration.file.FileConfiguration
@@ -18,21 +18,21 @@ class SpigotConfig(
 
     private fun generateDefaultConfig() {
         arrayOf(
-            PluginConfig.SPIGOT_SERVER_NAME,
-            PluginConfig.DB_HOSTNAME,
-            PluginConfig.DB_PORT,
-            PluginConfig.DB_NAME,
-            PluginConfig.DB_USERNAME,
-            PluginConfig.DB_PASSWORD,
-            PluginConfig.REDIS_HOSTNAME,
-            PluginConfig.REDIS_PORT,
-            PluginConfig.REDIS_USERNAME,
-            PluginConfig.REDIS_PASSWORD,
-            PluginConfig.ERROR_REPORTING_SENTRY_ENABLED,
-            PluginConfig.ERROR_REPORTING_SENTRY_DSN,
-            PluginConfig.SHARED_CACHE_ADAPTER,
-            PluginConfig.SHARED_CACHE_FILE_RELATIVE_PATH,
-            PluginConfig.INTEGRATION_DYNMAP_WARP_ICON,
+            ConfigKeys.SPIGOT_SERVER_NAME,
+            ConfigKeys.DB_HOSTNAME,
+            ConfigKeys.DB_PORT,
+            ConfigKeys.DB_NAME,
+            ConfigKeys.DB_USERNAME,
+            ConfigKeys.DB_PASSWORD,
+            ConfigKeys.REDIS_HOSTNAME,
+            ConfigKeys.REDIS_PORT,
+            ConfigKeys.REDIS_USERNAME,
+            ConfigKeys.REDIS_PASSWORD,
+            ConfigKeys.ERROR_REPORTING_SENTRY_ENABLED,
+            ConfigKeys.ERROR_REPORTING_SENTRY_DSN,
+            ConfigKeys.SHARED_CACHE_ADAPTER,
+            ConfigKeys.SHARED_CACHE_FILE_RELATIVE_PATH,
+            ConfigKeys.INTEGRATION_DYNMAP_WARP_ICON,
         ).forEach { key ->
             config.addDefault(key.key, key.defaultValue)
         }
@@ -40,7 +40,7 @@ class SpigotConfig(
         plugin.saveConfig()
     }
 
-    override fun <T> get(key: PluginConfig.ConfigPath<T>): T {
+    override fun <T> get(key: ConfigKeys.ConfigPath<T>): T {
         val value = config.get(key.key) as T
         if (value != null) {
             return value
@@ -52,7 +52,7 @@ class SpigotConfig(
         return config.get(path)
     }
 
-    override fun <T> set(key: PluginConfig.ConfigPath<T>, value: T) {
+    override fun <T> set(key: ConfigKeys.ConfigPath<T>, value: T) {
         return config.set(key.key, value)
     }
 }

--- a/src/main/kotlin/com/projectcitybuild/modules/datetime/DateTimeProvider.kt
+++ b/src/main/kotlin/com/projectcitybuild/modules/datetime/DateTimeProvider.kt
@@ -1,6 +1,6 @@
 package com.projectcitybuild.modules.datetime
 
-import com.projectcitybuild.modules.config.ConfigKeys
+import com.projectcitybuild.modules.config.ConfigKey
 import com.projectcitybuild.modules.config.PlatformConfig
 import com.projectcitybuild.modules.datetime.formatter.DateTimeFormatter
 import com.projectcitybuild.modules.datetime.formatter.DateTimeFormatterImpl
@@ -18,10 +18,10 @@ class DateTimeProvider {
     fun provideDateTimeFormatter(config: PlatformConfig): DateTimeFormatter {
         return DateTimeFormatterImpl(
             locale = Locale.forLanguageTag(
-                config.get(ConfigKeys.TIME_LOCALE)
+                config.get(ConfigKey.TIME_LOCALE)
             ),
             timezone = ZoneId.of(
-                config.get(ConfigKeys.TIME_TIMEZONE)
+                config.get(ConfigKey.TIME_TIMEZONE)
             ),
         )
     }

--- a/src/main/kotlin/com/projectcitybuild/modules/datetime/DateTimeProvider.kt
+++ b/src/main/kotlin/com/projectcitybuild/modules/datetime/DateTimeProvider.kt
@@ -1,6 +1,6 @@
 package com.projectcitybuild.modules.datetime
 
-import com.projectcitybuild.entities.PluginConfig
+import com.projectcitybuild.modules.config.PluginConfig
 import com.projectcitybuild.modules.config.PlatformConfig
 import com.projectcitybuild.modules.datetime.formatter.DateTimeFormatter
 import com.projectcitybuild.modules.datetime.formatter.DateTimeFormatterImpl

--- a/src/main/kotlin/com/projectcitybuild/modules/datetime/DateTimeProvider.kt
+++ b/src/main/kotlin/com/projectcitybuild/modules/datetime/DateTimeProvider.kt
@@ -1,6 +1,6 @@
 package com.projectcitybuild.modules.datetime
 
-import com.projectcitybuild.modules.config.PluginConfig
+import com.projectcitybuild.modules.config.ConfigKeys
 import com.projectcitybuild.modules.config.PlatformConfig
 import com.projectcitybuild.modules.datetime.formatter.DateTimeFormatter
 import com.projectcitybuild.modules.datetime.formatter.DateTimeFormatterImpl
@@ -18,10 +18,10 @@ class DateTimeProvider {
     fun provideDateTimeFormatter(config: PlatformConfig): DateTimeFormatter {
         return DateTimeFormatterImpl(
             locale = Locale.forLanguageTag(
-                config.get(PluginConfig.TIME_LOCALE)
+                config.get(ConfigKeys.TIME_LOCALE)
             ),
             timezone = ZoneId.of(
-                config.get(PluginConfig.TIME_TIMEZONE)
+                config.get(ConfigKeys.TIME_TIMEZONE)
             ),
         )
     }

--- a/src/main/kotlin/com/projectcitybuild/modules/errorreporting/adapters/SentryErrorReporter.kt
+++ b/src/main/kotlin/com/projectcitybuild/modules/errorreporting/adapters/SentryErrorReporter.kt
@@ -1,6 +1,6 @@
 package com.projectcitybuild.modules.errorreporting.adapters
 
-import com.projectcitybuild.modules.config.PluginConfig
+import com.projectcitybuild.modules.config.ConfigKeys
 import com.projectcitybuild.modules.config.PlatformConfig
 import com.projectcitybuild.modules.errorreporting.ErrorReporter
 import com.projectcitybuild.modules.logger.PlatformLogger
@@ -14,13 +14,13 @@ class SentryErrorReporter(
 ): ErrorReporter {
 
     override fun bootstrap() {
-        val enabled = config.get(PluginConfig.ERROR_REPORTING_SENTRY_ENABLED)
+        val enabled = config.get(ConfigKeys.ERROR_REPORTING_SENTRY_ENABLED)
         if (!enabled) return
 
         logger.info("Enabling error reporting")
 
         Sentry.init { options ->
-            options.dsn = config.get(PluginConfig.ERROR_REPORTING_SENTRY_DSN)
+            options.dsn = config.get(ConfigKeys.ERROR_REPORTING_SENTRY_DSN)
         }
     }
 

--- a/src/main/kotlin/com/projectcitybuild/modules/errorreporting/adapters/SentryErrorReporter.kt
+++ b/src/main/kotlin/com/projectcitybuild/modules/errorreporting/adapters/SentryErrorReporter.kt
@@ -1,6 +1,6 @@
 package com.projectcitybuild.modules.errorreporting.adapters
 
-import com.projectcitybuild.modules.config.ConfigKeys
+import com.projectcitybuild.modules.config.ConfigKey
 import com.projectcitybuild.modules.config.PlatformConfig
 import com.projectcitybuild.modules.errorreporting.ErrorReporter
 import com.projectcitybuild.modules.logger.PlatformLogger
@@ -14,13 +14,13 @@ class SentryErrorReporter(
 ): ErrorReporter {
 
     override fun bootstrap() {
-        val enabled = config.get(ConfigKeys.ERROR_REPORTING_SENTRY_ENABLED)
+        val enabled = config.get(ConfigKey.ERROR_REPORTING_SENTRY_ENABLED)
         if (!enabled) return
 
         logger.info("Enabling error reporting")
 
         Sentry.init { options ->
-            options.dsn = config.get(ConfigKeys.ERROR_REPORTING_SENTRY_DSN)
+            options.dsn = config.get(ConfigKey.ERROR_REPORTING_SENTRY_DSN)
         }
     }
 

--- a/src/main/kotlin/com/projectcitybuild/modules/errorreporting/adapters/SentryErrorReporter.kt
+++ b/src/main/kotlin/com/projectcitybuild/modules/errorreporting/adapters/SentryErrorReporter.kt
@@ -1,6 +1,6 @@
 package com.projectcitybuild.modules.errorreporting.adapters
 
-import com.projectcitybuild.entities.PluginConfig
+import com.projectcitybuild.modules.config.PluginConfig
 import com.projectcitybuild.modules.config.PlatformConfig
 import com.projectcitybuild.modules.errorreporting.ErrorReporter
 import com.projectcitybuild.modules.logger.PlatformLogger

--- a/src/main/kotlin/com/projectcitybuild/modules/logger/implementations/BungeecordLogger.kt
+++ b/src/main/kotlin/com/projectcitybuild/modules/logger/implementations/BungeecordLogger.kt
@@ -3,7 +3,9 @@ package com.projectcitybuild.modules.logger.implementations
 import com.projectcitybuild.modules.logger.PlatformLogger
 import java.util.logging.Logger
 
-class BungeecordLogger(private val logger: Logger): PlatformLogger {
+class BungeecordLogger(
+    private val logger: Logger
+): PlatformLogger {
 
     override fun verbose(message: String) {
         logger.finest(message)

--- a/src/main/kotlin/com/projectcitybuild/modules/sharedcache/SharedCacheSetProvider.kt
+++ b/src/main/kotlin/com/projectcitybuild/modules/sharedcache/SharedCacheSetProvider.kt
@@ -1,6 +1,6 @@
 package com.projectcitybuild.modules.sharedcache
 
-import com.projectcitybuild.modules.config.PluginConfig
+import com.projectcitybuild.modules.config.ConfigKeys
 import com.projectcitybuild.modules.config.PlatformConfig
 import com.projectcitybuild.modules.sharedcache.adapters.FlatFileSharedCacheSet
 import com.projectcitybuild.modules.sharedcache.adapters.RedisSharedCacheSet
@@ -16,7 +16,7 @@ class SharedCacheSetProvider {
         redisSharedCacheSet: RedisSharedCacheSet,
         flatFileSharedCacheSet: FlatFileSharedCacheSet,
     ): SharedCacheSet {
-        val adapter = config.get(PluginConfig.SHARED_CACHE_ADAPTER)
+        val adapter = config.get(ConfigKeys.SHARED_CACHE_ADAPTER)
 
         return when (adapter) {
             "redis" -> redisSharedCacheSet

--- a/src/main/kotlin/com/projectcitybuild/modules/sharedcache/SharedCacheSetProvider.kt
+++ b/src/main/kotlin/com/projectcitybuild/modules/sharedcache/SharedCacheSetProvider.kt
@@ -1,6 +1,6 @@
 package com.projectcitybuild.modules.sharedcache
 
-import com.projectcitybuild.entities.PluginConfig
+import com.projectcitybuild.modules.config.PluginConfig
 import com.projectcitybuild.modules.config.PlatformConfig
 import com.projectcitybuild.modules.sharedcache.adapters.FlatFileSharedCacheSet
 import com.projectcitybuild.modules.sharedcache.adapters.RedisSharedCacheSet

--- a/src/main/kotlin/com/projectcitybuild/modules/sharedcache/SharedCacheSetProvider.kt
+++ b/src/main/kotlin/com/projectcitybuild/modules/sharedcache/SharedCacheSetProvider.kt
@@ -1,6 +1,6 @@
 package com.projectcitybuild.modules.sharedcache
 
-import com.projectcitybuild.modules.config.ConfigKeys
+import com.projectcitybuild.modules.config.ConfigKey
 import com.projectcitybuild.modules.config.PlatformConfig
 import com.projectcitybuild.modules.sharedcache.adapters.FlatFileSharedCacheSet
 import com.projectcitybuild.modules.sharedcache.adapters.RedisSharedCacheSet
@@ -16,7 +16,7 @@ class SharedCacheSetProvider {
         redisSharedCacheSet: RedisSharedCacheSet,
         flatFileSharedCacheSet: FlatFileSharedCacheSet,
     ): SharedCacheSet {
-        val adapter = config.get(ConfigKeys.SHARED_CACHE_ADAPTER)
+        val adapter = config.get(ConfigKey.SHARED_CACHE_ADAPTER)
 
         return when (adapter) {
             "redis" -> redisSharedCacheSet

--- a/src/main/kotlin/com/projectcitybuild/modules/sharedcache/adapters/FlatFileSharedCacheSet.kt
+++ b/src/main/kotlin/com/projectcitybuild/modules/sharedcache/adapters/FlatFileSharedCacheSet.kt
@@ -1,6 +1,6 @@
 package com.projectcitybuild.modules.sharedcache.adapters
 
-import com.projectcitybuild.modules.config.ConfigKeys
+import com.projectcitybuild.modules.config.ConfigKey
 import com.projectcitybuild.modules.config.PlatformConfig
 import com.projectcitybuild.modules.sharedcache.SharedCacheSet
 import kotlinx.serialization.Serializable
@@ -23,7 +23,7 @@ class FlatFileSharedCacheSet @Inject constructor(
     override lateinit var key: String
 
     private val folder by lazy {
-        val relativePath = config.get(ConfigKeys.SHARED_CACHE_FILE_RELATIVE_PATH)
+        val relativePath = config.get(ConfigKey.SHARED_CACHE_FILE_RELATIVE_PATH)
         baseFolder.resolve(relativePath)
     }
 

--- a/src/main/kotlin/com/projectcitybuild/modules/sharedcache/adapters/FlatFileSharedCacheSet.kt
+++ b/src/main/kotlin/com/projectcitybuild/modules/sharedcache/adapters/FlatFileSharedCacheSet.kt
@@ -1,6 +1,6 @@
 package com.projectcitybuild.modules.sharedcache.adapters
 
-import com.projectcitybuild.modules.config.PluginConfig
+import com.projectcitybuild.modules.config.ConfigKeys
 import com.projectcitybuild.modules.config.PlatformConfig
 import com.projectcitybuild.modules.sharedcache.SharedCacheSet
 import kotlinx.serialization.Serializable
@@ -23,7 +23,7 @@ class FlatFileSharedCacheSet @Inject constructor(
     override lateinit var key: String
 
     private val folder by lazy {
-        val relativePath = config.get(PluginConfig.SHARED_CACHE_FILE_RELATIVE_PATH)
+        val relativePath = config.get(ConfigKeys.SHARED_CACHE_FILE_RELATIVE_PATH)
         baseFolder.resolve(relativePath)
     }
 

--- a/src/main/kotlin/com/projectcitybuild/modules/sharedcache/adapters/FlatFileSharedCacheSet.kt
+++ b/src/main/kotlin/com/projectcitybuild/modules/sharedcache/adapters/FlatFileSharedCacheSet.kt
@@ -1,6 +1,6 @@
 package com.projectcitybuild.modules.sharedcache.adapters
 
-import com.projectcitybuild.entities.PluginConfig
+import com.projectcitybuild.modules.config.PluginConfig
 import com.projectcitybuild.modules.config.PlatformConfig
 import com.projectcitybuild.modules.sharedcache.SharedCacheSet
 import kotlinx.serialization.Serializable

--- a/src/main/kotlin/com/projectcitybuild/platforms/bungeecord/BungeecordPlatform.kt
+++ b/src/main/kotlin/com/projectcitybuild/platforms/bungeecord/BungeecordPlatform.kt
@@ -1,14 +1,16 @@
 package com.projectcitybuild.platforms.bungeecord
 
 import com.projectcitybuild.core.contracts.BungeecordFeatureModule
+import com.projectcitybuild.core.infrastructure.database.DataSource
+import com.projectcitybuild.core.infrastructure.network.APIClientImpl
 import com.projectcitybuild.entities.Channel
 import com.projectcitybuild.modules.channels.bungeecord.BungeecordMessageListener
+import com.projectcitybuild.modules.config.ConfigKey
+import com.projectcitybuild.modules.config.PlatformConfig
 import com.projectcitybuild.modules.config.implementations.BungeecordConfig
-import com.projectcitybuild.core.infrastructure.database.DataSource
 import com.projectcitybuild.modules.errorreporting.ErrorReporter
 import com.projectcitybuild.modules.logger.PlatformLogger
 import com.projectcitybuild.modules.logger.implementations.BungeecordLogger
-import com.projectcitybuild.core.infrastructure.network.APIClientImpl
 import com.projectcitybuild.modules.permissions.Permissions
 import com.projectcitybuild.modules.playerconfig.PlayerConfigCache
 import com.projectcitybuild.modules.scheduler.implementations.BungeecordScheduler
@@ -45,6 +47,7 @@ class BungeecordPlatform: Plugin() {
     class Container @Inject constructor(
         private val proxyServer: ProxyServer,
         private val logger: PlatformLogger,
+        private val config: PlatformConfig,
         private val dataSource: DataSource,
         private val commandRegistry: BungeecordCommandRegistry,
         private val listenerRegistry: BungeecordListenerRegistry,
@@ -68,6 +71,22 @@ class BungeecordPlatform: Plugin() {
                     module.bungeecordCommands.forEach { commandRegistry.register(it) }
                     module.bungeecordListeners.forEach { listenerRegistry.register(it) }
                     module.bungeecordSubChannelListeners.forEach { subChannelListener.register(it) }
+                }
+
+                if (!config.get(ConfigKey.API_ENABLED)) {
+                    """
+                    #********************************************************
+                    #
+                    #  PCB NETWORK API DISABLED VIA CONFIG
+                    #  
+                    #  This will prevent the plugin from checking bans and syncing ranks. 
+                    #  If this is not a local dev environment, the API should be enabled!
+                    #  
+                    #********************************************************
+                    """
+                    .trimMargin("#")
+                    .split("\n")
+                    .forEach { logger.warning(it) }
                 }
 
             }.onFailure {

--- a/src/main/kotlin/com/projectcitybuild/platforms/spigot/SpigotPlatform.kt
+++ b/src/main/kotlin/com/projectcitybuild/platforms/spigot/SpigotPlatform.kt
@@ -5,7 +5,7 @@ import com.projectcitybuild.core.infrastructure.database.DataSource
 import com.projectcitybuild.core.infrastructure.network.APIClientImpl
 import com.projectcitybuild.core.infrastructure.redis.RedisConnection
 import com.projectcitybuild.entities.Channel
-import com.projectcitybuild.entities.PluginConfig
+import com.projectcitybuild.modules.config.PluginConfig
 import com.projectcitybuild.modules.channels.spigot.SpigotMessageListener
 import com.projectcitybuild.modules.config.PlatformConfig
 import com.projectcitybuild.modules.config.implementations.SpigotConfig

--- a/src/main/kotlin/com/projectcitybuild/platforms/spigot/SpigotPlatform.kt
+++ b/src/main/kotlin/com/projectcitybuild/platforms/spigot/SpigotPlatform.kt
@@ -5,7 +5,7 @@ import com.projectcitybuild.core.infrastructure.database.DataSource
 import com.projectcitybuild.core.infrastructure.network.APIClientImpl
 import com.projectcitybuild.core.infrastructure.redis.RedisConnection
 import com.projectcitybuild.entities.Channel
-import com.projectcitybuild.modules.config.PluginConfig
+import com.projectcitybuild.modules.config.ConfigKeys
 import com.projectcitybuild.modules.channels.spigot.SpigotMessageListener
 import com.projectcitybuild.modules.config.PlatformConfig
 import com.projectcitybuild.modules.config.implementations.SpigotConfig
@@ -56,7 +56,7 @@ class SpigotPlatform: JavaPlugin() {
         private val redisConnection: RedisConnection,
     ) {
         private val isRedisEnabled: Boolean
-            get() = config.get(PluginConfig.SHARED_CACHE_ADAPTER) == "redis"
+            get() = config.get(ConfigKeys.SHARED_CACHE_ADAPTER) == "redis"
 
         fun onEnable(server: Server) {
             errorReporter.bootstrap()

--- a/src/main/kotlin/com/projectcitybuild/platforms/spigot/SpigotPlatform.kt
+++ b/src/main/kotlin/com/projectcitybuild/platforms/spigot/SpigotPlatform.kt
@@ -5,7 +5,7 @@ import com.projectcitybuild.core.infrastructure.database.DataSource
 import com.projectcitybuild.core.infrastructure.network.APIClientImpl
 import com.projectcitybuild.core.infrastructure.redis.RedisConnection
 import com.projectcitybuild.entities.Channel
-import com.projectcitybuild.modules.config.ConfigKeys
+import com.projectcitybuild.modules.config.ConfigKey
 import com.projectcitybuild.modules.channels.spigot.SpigotMessageListener
 import com.projectcitybuild.modules.config.PlatformConfig
 import com.projectcitybuild.modules.config.implementations.SpigotConfig
@@ -56,7 +56,7 @@ class SpigotPlatform: JavaPlugin() {
         private val redisConnection: RedisConnection,
     ) {
         private val isRedisEnabled: Boolean
-            get() = config.get(ConfigKeys.SHARED_CACHE_ADAPTER) == "redis"
+            get() = config.get(ConfigKey.SHARED_CACHE_ADAPTER) == "redis"
 
         fun onEnable(server: Server) {
             errorReporter.bootstrap()

--- a/src/main/kotlin/com/projectcitybuild/platforms/spigot/SpigotPlatform.kt
+++ b/src/main/kotlin/com/projectcitybuild/platforms/spigot/SpigotPlatform.kt
@@ -5,8 +5,8 @@ import com.projectcitybuild.core.infrastructure.database.DataSource
 import com.projectcitybuild.core.infrastructure.network.APIClientImpl
 import com.projectcitybuild.core.infrastructure.redis.RedisConnection
 import com.projectcitybuild.entities.Channel
-import com.projectcitybuild.modules.config.ConfigKey
 import com.projectcitybuild.modules.channels.spigot.SpigotMessageListener
+import com.projectcitybuild.modules.config.ConfigKey
 import com.projectcitybuild.modules.config.PlatformConfig
 import com.projectcitybuild.modules.config.implementations.SpigotConfig
 import com.projectcitybuild.modules.errorreporting.ErrorReporter

--- a/src/test/com/projectcitybuild/features/ranksync/usecases/UpdatePlayerGroupsUseCaseTest.kt
+++ b/src/test/com/projectcitybuild/features/ranksync/usecases/UpdatePlayerGroupsUseCaseTest.kt
@@ -2,7 +2,7 @@ package com.projectcitybuild.features.ranksync.usecases
 
 import com.projectcitybuild.core.utilities.Failure
 import com.projectcitybuild.core.utilities.Success
-import com.projectcitybuild.modules.config.PluginConfig
+import com.projectcitybuild.modules.config.ConfigKeys
 import com.projectcitybuild.entities.responses.ApiError
 import com.projectcitybuild.entities.responses.ApiResponse
 import com.projectcitybuild.entities.responses.AuthPlayerGroups
@@ -77,7 +77,7 @@ class UpdatePlayerGroupsUseCaseTest {
     fun `should assign player to guest group if no groups`() = runTest {
         val playerUUID = UUID.randomUUID()
 
-        `when`(config.get(PluginConfig.GROUPS_GUEST)).thenReturn("guest_group")
+        `when`(config.get(ConfigKeys.GROUPS_GUEST)).thenReturn("guest_group")
 
         apiClient.result = apiResponseMock(groups = emptyList())
 

--- a/src/test/com/projectcitybuild/features/ranksync/usecases/UpdatePlayerGroupsUseCaseTest.kt
+++ b/src/test/com/projectcitybuild/features/ranksync/usecases/UpdatePlayerGroupsUseCaseTest.kt
@@ -2,7 +2,7 @@ package com.projectcitybuild.features.ranksync.usecases
 
 import com.projectcitybuild.core.utilities.Failure
 import com.projectcitybuild.core.utilities.Success
-import com.projectcitybuild.modules.config.ConfigKeys
+import com.projectcitybuild.modules.config.ConfigKey
 import com.projectcitybuild.entities.responses.ApiError
 import com.projectcitybuild.entities.responses.ApiResponse
 import com.projectcitybuild.entities.responses.AuthPlayerGroups
@@ -77,7 +77,7 @@ class UpdatePlayerGroupsUseCaseTest {
     fun `should assign player to guest group if no groups`() = runTest {
         val playerUUID = UUID.randomUUID()
 
-        `when`(config.get(ConfigKeys.GROUPS_GUEST)).thenReturn("guest_group")
+        `when`(config.get(ConfigKey.GROUPS_GUEST)).thenReturn("guest_group")
 
         apiClient.result = apiResponseMock(groups = emptyList())
 

--- a/src/test/com/projectcitybuild/features/ranksync/usecases/UpdatePlayerGroupsUseCaseTest.kt
+++ b/src/test/com/projectcitybuild/features/ranksync/usecases/UpdatePlayerGroupsUseCaseTest.kt
@@ -2,7 +2,7 @@ package com.projectcitybuild.features.ranksync.usecases
 
 import com.projectcitybuild.core.utilities.Failure
 import com.projectcitybuild.core.utilities.Success
-import com.projectcitybuild.entities.PluginConfig
+import com.projectcitybuild.modules.config.PluginConfig
 import com.projectcitybuild.entities.responses.ApiError
 import com.projectcitybuild.entities.responses.ApiResponse
 import com.projectcitybuild.entities.responses.AuthPlayerGroups

--- a/src/test/com/projectcitybuild/features/warps/usecases/WarpListUseCaseTest.kt
+++ b/src/test/com/projectcitybuild/features/warps/usecases/WarpListUseCaseTest.kt
@@ -1,6 +1,6 @@
 package com.projectcitybuild.features.warps.usecases
 
-import com.projectcitybuild.modules.config.PluginConfig
+import com.projectcitybuild.modules.config.ConfigKeys
 import com.projectcitybuild.features.warps.repositories.WarpRepository
 import com.projectcitybuild.features.warps.usecases.warplist.WarpListUseCase
 import com.projectcitybuild.modules.config.PlatformConfig
@@ -31,7 +31,7 @@ class WarpListUseCaseTest {
     fun `should return all warps sorted`() = runTest {
         val warps = listOf("b", "c", "a",)
         `when`(warpRepository.names()).thenReturn(warps)
-        `when`(config.get(PluginConfig.WARPS_PER_PAGE)).thenReturn(warps.size)
+        `when`(config.get(ConfigKeys.WARPS_PER_PAGE)).thenReturn(warps.size)
 
         val received = useCase.getList(page = 1)
         val expected = listOf("a", "b", "c")
@@ -44,7 +44,7 @@ class WarpListUseCaseTest {
         val warps = MutableList(3) { index -> "warp_$index" }
 
         `when`(warpRepository.names()).thenReturn(warps)
-        `when`(config.get(PluginConfig.WARPS_PER_PAGE)).thenReturn(3)
+        `when`(config.get(ConfigKeys.WARPS_PER_PAGE)).thenReturn(3)
 
         val received = useCase.getList(page = 1)
 
@@ -61,7 +61,7 @@ class WarpListUseCaseTest {
         val warps = MutableList(5) { index -> "warp_$index" }
 
         `when`(warpRepository.names()).thenReturn(warps)
-        `when`(config.get(PluginConfig.WARPS_PER_PAGE)).thenReturn(2)
+        `when`(config.get(ConfigKeys.WARPS_PER_PAGE)).thenReturn(2)
 
         val firstPage = useCase.getList(page = 1)
         assertEquals(listOf("warp_0", "warp_1"), firstPage?.warps)

--- a/src/test/com/projectcitybuild/features/warps/usecases/WarpListUseCaseTest.kt
+++ b/src/test/com/projectcitybuild/features/warps/usecases/WarpListUseCaseTest.kt
@@ -1,6 +1,6 @@
 package com.projectcitybuild.features.warps.usecases
 
-import com.projectcitybuild.modules.config.ConfigKeys
+import com.projectcitybuild.modules.config.ConfigKey
 import com.projectcitybuild.features.warps.repositories.WarpRepository
 import com.projectcitybuild.features.warps.usecases.warplist.WarpListUseCase
 import com.projectcitybuild.modules.config.PlatformConfig
@@ -31,7 +31,7 @@ class WarpListUseCaseTest {
     fun `should return all warps sorted`() = runTest {
         val warps = listOf("b", "c", "a",)
         `when`(warpRepository.names()).thenReturn(warps)
-        `when`(config.get(ConfigKeys.WARPS_PER_PAGE)).thenReturn(warps.size)
+        `when`(config.get(ConfigKey.WARPS_PER_PAGE)).thenReturn(warps.size)
 
         val received = useCase.getList(page = 1)
         val expected = listOf("a", "b", "c")
@@ -44,7 +44,7 @@ class WarpListUseCaseTest {
         val warps = MutableList(3) { index -> "warp_$index" }
 
         `when`(warpRepository.names()).thenReturn(warps)
-        `when`(config.get(ConfigKeys.WARPS_PER_PAGE)).thenReturn(3)
+        `when`(config.get(ConfigKey.WARPS_PER_PAGE)).thenReturn(3)
 
         val received = useCase.getList(page = 1)
 
@@ -61,7 +61,7 @@ class WarpListUseCaseTest {
         val warps = MutableList(5) { index -> "warp_$index" }
 
         `when`(warpRepository.names()).thenReturn(warps)
-        `when`(config.get(ConfigKeys.WARPS_PER_PAGE)).thenReturn(2)
+        `when`(config.get(ConfigKey.WARPS_PER_PAGE)).thenReturn(2)
 
         val firstPage = useCase.getList(page = 1)
         assertEquals(listOf("warp_0", "warp_1"), firstPage?.warps)

--- a/src/test/com/projectcitybuild/features/warps/usecases/WarpListUseCaseTest.kt
+++ b/src/test/com/projectcitybuild/features/warps/usecases/WarpListUseCaseTest.kt
@@ -1,6 +1,6 @@
 package com.projectcitybuild.features.warps.usecases
 
-import com.projectcitybuild.entities.PluginConfig
+import com.projectcitybuild.modules.config.PluginConfig
 import com.projectcitybuild.features.warps.repositories.WarpRepository
 import com.projectcitybuild.features.warps.usecases.warplist.WarpListUseCase
 import com.projectcitybuild.modules.config.PlatformConfig


### PR DESCRIPTION
Closes #128 

Allows the plugin to be run without hitting the Project City Build API. While not ideal, it at least allows development in a local environment for those who can't get an access token for working with the API.

To disable the API, edit the PCBridge `config.yml` file on Bungeecord:

```
api:
  enabled: false
```