### PR TITLE
Set starting world to Hub during migration

### DIFF
--- a/src/main/kotlin/com/projectcitybuild/features/utilities/usecases/ImportInventoriesUseCase.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/utilities/usecases/ImportInventoriesUseCase.kt
@@ -244,7 +244,8 @@ class ImportInventoriesUseCase @Inject constructor(
             }
             globalPlayerFile.let { configFile ->
                 JsonConfiguration.loadConfiguration(configFile).apply {
-                    set("playerData.lastWorld", profile.lastWorldName ?: "hub") // Default to `hub` if no world
+//                    set("playerData.lastWorld", profile.lastWorldName ?: "hub") // Default to `hub` if no world
+                    set("playerData.lastWorld", "hub") // Set to `hub` because it will be the "default" world folder that has all player data now
                     set("playerData.shouldLoad", true) // TODO: should this be false...?
                     set("playerData.lastKnownName", profile.lastKnownName)
 


### PR DESCRIPTION
Sets the `lastWorld` of every player's multiverse config to be `hub`. 

This will ensure that the correct inventory is loaded when the user enters the server for the first time after the migration, because the `hub` world will become the new default world.