### PR TITLE
Use LuckPerms default group for guests

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ import java.util.Properties
 val generatedVersionDir = "$buildDir/generated-resources"
 
 group = "com.projectcitybuild"
-version = "4.1.0"
+version = "4.1.1"
 
 plugins {
     kotlin("jvm") version "1.6.10"

--- a/src/main/kotlin/com/projectcitybuild/modules/config/ConfigKey.kt
+++ b/src/main/kotlin/com/projectcitybuild/modules/config/ConfigKey.kt
@@ -31,7 +31,6 @@ sealed class ConfigKey {
         val TIME_TIMEZONE = "time.timezone" defaultTo "UTC"
         val TIME_LOCALE = "time.locale" defaultTo "en-us"
 
-        val GROUPS_GUEST = "groups.guest" defaultTo "guest"
         val GROUPS_BUILD_PRIORITY = "groups.build_priority" defaultTo arrayListOf(
             "architect",
             "engineer",

--- a/src/main/kotlin/com/projectcitybuild/repositories/PlayerGroupRepository.kt
+++ b/src/main/kotlin/com/projectcitybuild/repositories/PlayerGroupRepository.kt
@@ -2,8 +2,6 @@ package com.projectcitybuild.repositories
 
 import com.projectcitybuild.core.http.APIClient
 import com.projectcitybuild.core.http.APIRequestFactory
-import com.projectcitybuild.entities.responses.Group
-import com.projectcitybuild.modules.config.ConfigKey
 import com.projectcitybuild.modules.config.PlatformConfig
 import com.projectcitybuild.modules.logger.PlatformLogger
 import java.util.UUID
@@ -29,11 +27,8 @@ class PlayerGroupRepository @Inject constructor(
             throw e
         }
 
-        val groups: List<Group> = response.data?.groups ?: listOf()
-
-        return groups
-            .mapNotNull { it.minecraftName }
-            .ifEmpty { listOf(config.get(ConfigKey.GROUPS_GUEST)) }
+        return response.data?.groups
+            ?.mapNotNull { it.minecraftName } ?: listOf()
     }
 
     @Throws(AccountNotLinkedException::class)

--- a/src/main/kotlin/com/projectcitybuild/repositories/PlayerGroupRepository.kt
+++ b/src/main/kotlin/com/projectcitybuild/repositories/PlayerGroupRepository.kt
@@ -28,7 +28,8 @@ class PlayerGroupRepository @Inject constructor(
         }
 
         return response.data?.groups
-            ?.mapNotNull { it.minecraftName } ?: listOf()
+            ?.mapNotNull { it.minecraftName }
+            ?: listOf()
     }
 
     @Throws(AccountNotLinkedException::class)

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,6 +1,6 @@
 main: com.projectcitybuild.plugin.SpigotPlugin
 name: PCBridge
-version: 4.1.0
+version: 4.1.1
 softdepend:
   - LuckPerms
   - dynmap


### PR DESCRIPTION
Stops assigning players without a group to the custom Guest group.
Thereby using LuckPerms' default group for guests now