### PR TITLE
Add telemetry

### DIFF
--- a/src/main/kotlin/com/projectcitybuild/core/http/clients/PCBClient.kt
+++ b/src/main/kotlin/com/projectcitybuild/core/http/clients/PCBClient.kt
@@ -4,6 +4,7 @@ import com.projectcitybuild.entities.requests.pcb.AuthAPIRequest
 import com.projectcitybuild.entities.requests.pcb.BalanceAPIRequest
 import com.projectcitybuild.entities.requests.pcb.BanAPIRequest
 import com.projectcitybuild.entities.requests.pcb.DonorAPIRequest
+import com.projectcitybuild.entities.requests.pcb.TelemetryAPIRequest
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
@@ -17,10 +18,11 @@ class PCBClient(
 ) {
     private val instance: Retrofit = build()
 
-    val banApi: BanAPIRequest = instance.create(BanAPIRequest::class.java)
-    val authApi: AuthAPIRequest = instance.create(AuthAPIRequest::class.java)
-    val balanceApi: BalanceAPIRequest = instance.create(BalanceAPIRequest::class.java)
-    val donorApi: DonorAPIRequest = instance.create(DonorAPIRequest::class.java)
+    val banAPI: BanAPIRequest = instance.create(BanAPIRequest::class.java)
+    val authAPI: AuthAPIRequest = instance.create(AuthAPIRequest::class.java)
+    val balanceAPI: BalanceAPIRequest = instance.create(BalanceAPIRequest::class.java)
+    val donorAPI: DonorAPIRequest = instance.create(DonorAPIRequest::class.java)
+    val telemetryAPI: TelemetryAPIRequest = instance.create(TelemetryAPIRequest::class.java)
 
     private fun build(): Retrofit {
         val authenticatedClient = makeAuthenticatedClient()

--- a/src/main/kotlin/com/projectcitybuild/core/http/clients/PCBClient.kt
+++ b/src/main/kotlin/com/projectcitybuild/core/http/clients/PCBClient.kt
@@ -33,14 +33,22 @@ class PCBClient(
             .build()
     }
 
+    private fun token(url: String): String {
+        return if (url.contains("balance") || url.contains("telemetry")) {
+            authToken
+        } else {
+            oldAuthToken
+        }
+    }
+
     private fun makeAuthenticatedClient(): OkHttpClient {
         var clientFactory = OkHttpClient().newBuilder()
             .addInterceptor { chain ->
                 // Add access token as header to each API request
                 val request = chain.request()
 
-                val token = if (request.url.toString().contains("balance")) authToken else oldAuthToken
-                val requestBuilder = request.newBuilder().header("Authorization", "Bearer $token")
+                val authToken = token(url = request.url.toString())
+                val requestBuilder = request.newBuilder().header("Authorization", "Bearer $authToken")
                 val nextRequest = requestBuilder.build()
 
                 chain.proceed(nextRequest)

--- a/src/main/kotlin/com/projectcitybuild/entities/requests/pcb/TelemetryAPIRequest.kt
+++ b/src/main/kotlin/com/projectcitybuild/entities/requests/pcb/TelemetryAPIRequest.kt
@@ -1,0 +1,16 @@
+package com.projectcitybuild.entities.requests.pcb
+
+import com.projectcitybuild.entities.responses.ApiResponse
+import retrofit2.http.Field
+import retrofit2.http.FormUrlEncoded
+import retrofit2.http.POST
+
+interface TelemetryAPIRequest {
+
+    @FormUrlEncoded
+    @POST("v2/minecraft/telemetry/seen")
+    suspend fun seen(
+        @Field(value = "uuid") playerUUID: String,
+        @Field(value = "alias") playerName: String,
+    ): ApiResponse<Unit>
+}

--- a/src/main/kotlin/com/projectcitybuild/features/ranksync/usecases/GenerateAccountVerificationURLUseCase.kt
+++ b/src/main/kotlin/com/projectcitybuild/features/ranksync/usecases/GenerateAccountVerificationURLUseCase.kt
@@ -21,7 +21,7 @@ class GenerateAccountVerificationURLUseCase @Inject constructor(
 
     suspend fun generate(playerUUID: UUID): Result<VerificationURL, FailureReason> {
         try {
-            val authApi = apiRequestFactory.pcb.authApi
+            val authApi = apiRequestFactory.pcb.authAPI
             val response = apiClient.execute { authApi.getVerificationUrl(uuid = playerUUID.toString()) }
 
             return if (response.data == null || response.data.url.isEmpty()) {

--- a/src/main/kotlin/com/projectcitybuild/plugin/SpigotContainer.kt
+++ b/src/main/kotlin/com/projectcitybuild/plugin/SpigotContainer.kt
@@ -27,6 +27,7 @@ import com.projectcitybuild.plugin.listeners.FirstTimeJoinMessageListener
 import com.projectcitybuild.plugin.listeners.PlayerCacheListener
 import com.projectcitybuild.plugin.listeners.ServerJoinMessageListener
 import com.projectcitybuild.plugin.listeners.SyncRankLoginListener
+import com.projectcitybuild.plugin.listeners.TelemetryListener
 import com.projectcitybuild.plugin.listeners.WelcomeMessageListener
 import javax.inject.Inject
 
@@ -101,6 +102,7 @@ class SpigotContainer @Inject constructor(
         playerCacheListener: PlayerCacheListener,
         serverJoinMessageListener: ServerJoinMessageListener,
         syncRankLoginListener: SyncRankLoginListener,
+        telemetryListener: TelemetryListener,
         welcomeMessageListener: WelcomeMessageListener,
     ) {
         val enabled: List<SpigotListener> = listOf(
@@ -110,6 +112,7 @@ class SpigotContainer @Inject constructor(
             playerCacheListener,
             serverJoinMessageListener,
             syncRankLoginListener,
+            telemetryListener,
             welcomeMessageListener,
         )
     }

--- a/src/main/kotlin/com/projectcitybuild/plugin/listeners/TelemetryListener.kt
+++ b/src/main/kotlin/com/projectcitybuild/plugin/listeners/TelemetryListener.kt
@@ -12,15 +12,15 @@ class TelemetryListener @Inject constructor(
 ) : SpigotListener {
 
     @EventHandler
-    suspend fun onPlayerJoin(event: PlayerJoinEvent)
-        = telemetryRepository.playerSeen(
+    suspend fun onPlayerJoin(event: PlayerJoinEvent) =
+        telemetryRepository.playerSeen(
             playerUUID = event.player.uniqueId,
             playerName = event.player.name,
         )
 
     @EventHandler
-    suspend fun onPlayerLeave(event: PlayerQuitEvent)
-        = telemetryRepository.playerSeen(
+    suspend fun onPlayerLeave(event: PlayerQuitEvent) =
+        telemetryRepository.playerSeen(
             playerUUID = event.player.uniqueId,
             playerName = event.player.name,
         )

--- a/src/main/kotlin/com/projectcitybuild/plugin/listeners/TelemetryListener.kt
+++ b/src/main/kotlin/com/projectcitybuild/plugin/listeners/TelemetryListener.kt
@@ -1,0 +1,27 @@
+package com.projectcitybuild.plugin.listeners
+
+import com.projectcitybuild.core.SpigotListener
+import com.projectcitybuild.repositories.TelemetryRepository
+import org.bukkit.event.EventHandler
+import org.bukkit.event.player.PlayerJoinEvent
+import org.bukkit.event.player.PlayerQuitEvent
+import javax.inject.Inject
+
+class TelemetryListener @Inject constructor(
+    private val telemetryRepository: TelemetryRepository,
+) : SpigotListener {
+
+    @EventHandler
+    suspend fun onPlayerJoin(event: PlayerJoinEvent)
+        = telemetryRepository.playerSeen(
+            playerUUID = event.player.uniqueId,
+            playerName = event.player.name,
+        )
+
+    @EventHandler
+    suspend fun onPlayerLeave(event: PlayerQuitEvent)
+        = telemetryRepository.playerSeen(
+            playerUUID = event.player.uniqueId,
+            playerName = event.player.name,
+        )
+}

--- a/src/main/kotlin/com/projectcitybuild/repositories/BanRepository.kt
+++ b/src/main/kotlin/com/projectcitybuild/repositories/BanRepository.kt
@@ -22,7 +22,7 @@ class BanRepository @Inject constructor(
         reason: String?
     ) {
         try {
-            val banApi = apiRequestFactory.pcb.banApi
+            val banApi = apiRequestFactory.pcb.banAPI
             apiClient.execute {
                 banApi.storeBan(
                     playerId = targetPlayerUUID.toString(),
@@ -46,7 +46,7 @@ class BanRepository @Inject constructor(
     @Throws(PlayerNotBannedException::class)
     suspend fun unban(targetPlayerUUID: UUID, staffId: UUID?) {
         try {
-            val banApi = apiRequestFactory.pcb.banApi
+            val banApi = apiRequestFactory.pcb.banAPI
             apiClient.execute {
                 banApi.storeUnban(
                     playerId = targetPlayerUUID.toString(),
@@ -64,7 +64,7 @@ class BanRepository @Inject constructor(
     }
 
     suspend fun get(targetPlayerUUID: UUID): GameBan? {
-        val banApi = apiRequestFactory.pcb.banApi
+        val banApi = apiRequestFactory.pcb.banAPI
         val response = apiClient.execute {
             banApi.requestStatus(
                 playerId = targetPlayerUUID.toString(),

--- a/src/main/kotlin/com/projectcitybuild/repositories/CurrencyRepository.kt
+++ b/src/main/kotlin/com/projectcitybuild/repositories/CurrencyRepository.kt
@@ -33,7 +33,7 @@ class CurrencyRepository @Inject constructor(
 
         CoroutineScope(Dispatchers.IO).launch {
             val response = apiClient.execute {
-                apiRequestFactory.pcb.balanceApi.get(
+                apiRequestFactory.pcb.balanceAPI.get(
                     uuid = playerUUID.toString(),
                 )
             }
@@ -72,7 +72,7 @@ class CurrencyRepository @Inject constructor(
         }
         CoroutineScope(Dispatchers.IO).launch {
             apiClient.execute {
-                apiRequestFactory.pcb.balanceApi.deduct(
+                apiRequestFactory.pcb.balanceAPI.deduct(
                     uuid = playerUUID.toString(),
                     amount = amount,
                     reason = reason,

--- a/src/main/kotlin/com/projectcitybuild/repositories/PlayerGroupRepository.kt
+++ b/src/main/kotlin/com/projectcitybuild/repositories/PlayerGroupRepository.kt
@@ -18,7 +18,7 @@ class PlayerGroupRepository @Inject constructor(
     @Throws(AccountNotLinkedException::class)
     suspend fun getGroups(playerUUID: UUID): List<String> {
         val response = try {
-            val authAPI = apiRequestFactory.pcb.authApi
+            val authAPI = apiRequestFactory.pcb.authAPI
             apiClient.execute { authAPI.getUserGroups(uuid = playerUUID.toString()) }
         } catch (e: APIClient.HTTPError) {
             if (e.errorBody?.id == "account_not_linked") {
@@ -35,7 +35,7 @@ class PlayerGroupRepository @Inject constructor(
     @Throws(AccountNotLinkedException::class)
     suspend fun getDonorTiers(playerUUID: UUID): List<String> {
         val response = try {
-            val donorAPI = apiRequestFactory.pcb.donorApi
+            val donorAPI = apiRequestFactory.pcb.donorAPI
             apiClient.execute { donorAPI.getDonationTier(playerUUID.toString()) }
         } catch (e: APIClient.HTTPError) {
             if (e.errorBody?.id == "account_not_linked") {

--- a/src/main/kotlin/com/projectcitybuild/repositories/TelemetryRepository.kt
+++ b/src/main/kotlin/com/projectcitybuild/repositories/TelemetryRepository.kt
@@ -1,0 +1,21 @@
+package com.projectcitybuild.repositories
+
+import com.projectcitybuild.core.http.APIClient
+import com.projectcitybuild.core.http.APIRequestFactory
+import java.util.UUID
+import javax.inject.Inject
+
+class TelemetryRepository @Inject constructor(
+    private val apiRequestFactory: APIRequestFactory,
+    private val apiClient: APIClient,
+) {
+    suspend fun playerSeen(playerUUID: UUID, playerName: String) {
+        val telemetryAPI = apiRequestFactory.pcb.telemetryAPI
+        apiClient.execute {
+            telemetryAPI.seen(
+                playerUUID = playerUUID.toString(),
+                playerName = playerName,
+            )
+        }
+    }
+}


### PR DESCRIPTION
Sends player connection events to the PCB backend so that we know when a player UUID was last seen