### PR TITLE
Fix exceptions thrown on async threads not being reported

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ import java.util.Properties
 val generatedVersionDir = "$buildDir/generated-resources"
 
 group = "com.projectcitybuild"
-version = "4.7.1"
+version = "4.7.2"
 
 plugins {
     kotlin("jvm") version "1.6.10"

--- a/src/main/kotlin/com/projectcitybuild/plugin/assembly/SpigotContainer.kt
+++ b/src/main/kotlin/com/projectcitybuild/plugin/assembly/SpigotContainer.kt
@@ -25,6 +25,7 @@ import com.projectcitybuild.plugin.integrations.gadgetsmenu.GadgetsMenuIntegrati
 import com.projectcitybuild.plugin.integrations.luckperms.LuckPermsIntegration
 import com.projectcitybuild.plugin.listeners.AsyncPlayerChatListener
 import com.projectcitybuild.plugin.listeners.AsyncPreLoginListener
+import com.projectcitybuild.plugin.listeners.ExceptionListener
 import com.projectcitybuild.plugin.listeners.FirstTimeJoinListener
 import com.projectcitybuild.plugin.listeners.PlayerJoinListener
 import com.projectcitybuild.plugin.listeners.PlayerQuitEvent
@@ -102,6 +103,7 @@ class SpigotContainer @Inject constructor(
 
     class Listeners @Inject constructor(
         asyncPlayerChatListener: AsyncPlayerChatListener,
+        exceptionListener: ExceptionListener,
         firstTimeJoinListener: FirstTimeJoinListener,
         asyncPreLoginListener: AsyncPreLoginListener,
         playerJoinListener: PlayerJoinListener,
@@ -110,6 +112,7 @@ class SpigotContainer @Inject constructor(
     ) {
         val enabled: List<SpigotListener> = listOf(
             asyncPlayerChatListener,
+            exceptionListener,
             firstTimeJoinListener,
             asyncPreLoginListener,
             playerJoinListener,

--- a/src/main/kotlin/com/projectcitybuild/plugin/listeners/ExceptionListener.kt
+++ b/src/main/kotlin/com/projectcitybuild/plugin/listeners/ExceptionListener.kt
@@ -1,0 +1,18 @@
+package com.projectcitybuild.plugin.listeners
+
+import com.github.shynixn.mccoroutine.bukkit.MCCoroutineExceptionEvent
+import com.projectcitybuild.core.SpigotListener
+import com.projectcitybuild.modules.errorreporting.ErrorReporter
+import org.bukkit.event.EventHandler
+import org.bukkit.event.EventPriority
+import javax.inject.Inject
+
+class ExceptionListener @Inject constructor(
+    private val errorReporter: ErrorReporter,
+) : SpigotListener {
+
+    @EventHandler(priority = EventPriority.HIGHEST)
+    fun onAsyncPlayerChatEvent(event: MCCoroutineExceptionEvent) {
+        errorReporter.report(event.exception)
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,6 +1,6 @@
 main: com.projectcitybuild.plugin.SpigotPlugin
 name: PCBridge
-version: 4.7.1
+version: 4.7.2
 softdepend:
   - LuckPerms
   - dynmap


### PR DESCRIPTION
Exceptions thrown inside a coroutine (via MCCoroutine) can only be caught by listening for the `MCCoroutineExceptionEvent` event via the Spigot event listener

https://shynixn.github.io/MCCoroutine/wiki/site/exception/