### PR TITLE
Send correct message when receiving an invis item frame

### DIFF
--- a/pcbridge-spigot/src/main/kotlin/com/projectcitybuild/modules/buildtools/invisframes/commands/InvisFrameCommand.kt
+++ b/pcbridge-spigot/src/main/kotlin/com/projectcitybuild/modules/buildtools/invisframes/commands/InvisFrameCommand.kt
@@ -44,9 +44,9 @@ class InvisFrameCommand(
         })
 
         if (isGlowingFrame) {
-            player.send().info("You received an invisible item frame")
-        } else {
             player.send().info("You received an invisible glowing frame")
+        } else {
+            player.send().info("You received an invisible item frame")
         }
     }
 }


### PR DESCRIPTION
The normal and glowing invis item frame messages were swapped the wrong way around